### PR TITLE
fix(provider): AudioSource stream readiness + AriaCast cmd_stop pause UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ aprender-test/
 aprender-webui.png
 .playwright-mcp/
 ma-server/
+docker-compose.override.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,16 @@ All notable changes to this project will be documented in this file.
 - Lock model rewritten around per-queue ownership plus a per-request session id; same-queue reconnects no longer race the previous stream's teardown.
 - `get_stream_details` is now side-effect-free so preload paths can fetch stream metadata without claiming the source.
 - Lossless PCM auto-mode default sample rate is 48 kHz instead of 44.1 kHz when no source hint is available; the format pre-fetch still lifts auto-mode to the real source rate (e.g. 96 kHz for Hi-Res) before playback starts.
+- Bumped `ya-passport-auth` to 1.4.1. The QR-login flow used by own-mode authentication now talks to Yandex Passport's current `/pwl-yandex` BFF endpoints; the legacy registration-validations path that 1.3.0 still depended on is gone. Empty `magic/code/status` bodies (returned by the BFF while the QR is unscanned) are correctly treated as pending instead of raising an immediate auth error.
 
 ### Removed
 
 - The experimental `playback_mode = handoff` option and the related `handoff_heartbeat_interval` setting. Configurations carrying these values lose them silently on upgrade and the plugin always runs in the (formerly "stream") AudioSource path.
 - The experimental `enable_ui_integration` toggle. The new `AudioSource` flow renders a real queue card without any workaround, so the previous fake-queue mechanism — and the multi-user `player_filter` limitation documented in 2.2.9 — are gone.
+
+### Security
+
+- Closed CVE-2026-45409 (moderate) in transitive `idna` (3.11 → 3.16), pulled in via the `ya-passport-auth` 1.4.1 bump.
 
 ## [2.2.9] - 2026-05-13
 

--- a/provider/manifest.json
+++ b/provider/manifest.json
@@ -5,7 +5,7 @@
   "name": "Yandex Music Connect (Ynison)",
   "description": "Makes a Music Assistant player appear as a device in the Yandex Music app via the Ynison protocol.",
   "codeowners": ["@TrudenBoy"],
-  "requirements": ["ya-passport-auth==1.3.0"],
+  "requirements": ["ya-passport-auth==1.4.1"],
   "depends_on": "yandex_music",
   "documentation": "https://music-assistant.io/plugins/yandex-ynison/",
   "multi_instance": true

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -928,20 +928,29 @@ class YandexYnisonProvider(PluginProvider):
 
         # Unpause edge: we are entering this method because Ynison reports
         # the device active AND not paused. If `_paused_at_player` is set,
-        # we previously drove the MA player into PAUSED via `cmd_pause` —
-        # release it via `cmd_play` so the player drains the silence
-        # back-fill that the keep-alive loop produced and resumes real
-        # audio. Clear the flag unconditionally so a failure to cmd_play
-        # does not strand us in a "paused at player but flag stuck" state.
+        # we previously drove the MA QUEUE into PAUSED via
+        # `mass.player_queues.pause(queue_id)` — release it via
+        # `player_queues.play(queue_id)` so the queue's playback_state
+        # flips back, the player resumes draining the silence back-fill
+        # the keep-alive loop produced, and real audio continues. The
+        # queue id is the one MA handed us in `on_source_selected`
+        # (`_in_use_by_queue`); MUST match the id we paused on, otherwise
+        # the queue stays paused. Clear the flag unconditionally so a
+        # failure does not strand us in a "queue paused but flag stuck"
+        # state.
         if self._paused_at_player:
             self._paused_at_player = False
-            self.logger.info("Unpause: cmd_play(%s)", target_player_id)
-            try:
-                await self.mass.players.cmd_play(target_player_id)
-            except Exception:
-                self.logger.warning(
-                    "cmd_play failed for %s during unpause", target_player_id, exc_info=True
-                )
+            queue_id = self._in_use_by_queue
+            if queue_id:
+                self.logger.info("Unpause: player_queues.play(%s)", queue_id)
+                try:
+                    await self.mass.player_queues.play(queue_id)
+                except Exception:
+                    self.logger.warning(
+                        "player_queues.play failed for %s during unpause",
+                        queue_id,
+                        exc_info=True,
+                    )
 
         # Detect resume after pause: stream was stopped but player still associated
         needs_reselect = self._stream_stop_event.is_set()
@@ -1176,29 +1185,30 @@ class YandexYnisonProvider(PluginProvider):
           a full ``play_media → preload → ffmpeg restart`` cycle on resume
           (the original 2-3 s pause-resume cost we are eliminating).
         """
-        # Use `_active_player_id` (the actual player consuming our stream),
-        # NOT `_in_use_by_queue`. The latter is a queue identifier set by
-        # `on_source_selected`; MA's player-queues and player controllers
-        # share an id convention IN PRINCIPLE, but bridge players (e.g.
-        # Local Audio Out → Sendspin protocol bridge, registered as
-        # `spb_*` wrapping the bare ALSA player UUID) break it. queue_id
-        # is the bare UUID, the bridge is the player that actually owns
-        # the stream. cmd_pause on the bare UUID gets routed to the bare
-        # device successfully (audio stops) but the bridge's state machine
-        # — which the MA UI consults — never flips to PAUSED, so the UI
-        # keeps saying "playing" with a ticking progress bar.
-        # `_active_player_id` is the bridge, set by `on_source_selected`
-        # from its `player_id` parameter, and matches what `cmd_play` uses
-        # in `_activate_playback` on the unpause edge.
-        player_id = self._active_player_id
-        if not player_id:
-            self.logger.info("Pause requested but no active player (_active_player_id is None)")
+        # Drive the QUEUE, not the player. MA's UI for an AudioSource item
+        # reads playback_state from the queue that owns it, not from the
+        # underlying player. `mass.players.cmd_pause(player_id)` is a thin
+        # redirect to `mass.player_queues.pause(queue_id)` — it looks up the
+        # queue that the player belongs to and forwards. When a protocol
+        # bridge is involved (Local Audio Out → Sendspin `spb_*` wrapping
+        # the bare ALSA UUID), our streaming player is the bridge while the
+        # queue we hold a claim on belongs to the bare UUID. `cmd_pause`
+        # against the bridge searches for a queue keyed by the bridge id
+        # and finds either nothing or the wrong queue — the stream
+        # eventually stops because the bridge tears down the audio path,
+        # but our queue's playback_state never flips and the UI keeps
+        # ticking. Address both halves at the source: call
+        # `player_queues.pause(_in_use_by_queue)` directly. `_in_use_by_queue`
+        # IS the queue_id MA handed us in `on_source_selected`.
+        queue_id = self._in_use_by_queue
+        if not queue_id:
+            self.logger.info("Pause requested but no active queue (_in_use_by_queue is None)")
             return
-        self.logger.info("Pause: cmd_pause(%s)", player_id)
+        self.logger.info("Pause: player_queues.pause(%s)", queue_id)
         try:
-            await self.mass.players.cmd_pause(player_id)
+            await self.mass.player_queues.pause(queue_id)
         except Exception:
-            self.logger.warning("cmd_pause failed for %s", player_id, exc_info=True)
+            self.logger.warning("player_queues.pause failed for %s", queue_id, exc_info=True)
         self._paused_at_player = True
 
     # ------------------------------------------------------------------

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -238,15 +238,6 @@ class YandexYnisonProvider(PluginProvider):
         # state-handler twice in quick succession.
         self._command_idempotency: dict[tuple[str, str | None], float] = {}
 
-        # Tracks whether we have driven the MA player into PAUSED via
-        # `cmd_pause`. Paired with the silence-keepalive loop in
-        # `get_audio_stream`: cmd_pause is what makes the MA UI show paused
-        # and freezes the elapsed-time extrapolation; silence-keepalive is
-        # what keeps the stream connection alive across the pause without
-        # replaying the pre-pause buffer on resume. We flip back to PLAYING
-        # via `cmd_play` from `_activate_playback` on the unpause edge.
-        self._paused_at_player: bool = False
-
     # ------------------------------------------------------------------
     # Provider lifecycle
     # ------------------------------------------------------------------
@@ -424,114 +415,14 @@ class YandexYnisonProvider(PluginProvider):
                 track_id = self._ynison.state.current_track_id
                 self._current_streaming_track_id = track_id
 
-                # Silence keep-alive: when Ynison reports paused (whether at
-                # session start or after a mid-stream pause), yield PCM zeros
-                # at real-time rate so MA's outer buffer and the player
-                # connection stay alive. On unpause we transition straight
-                # into real audio without a play_media / preload / ffmpeg
-                # restart cycle — pause/resume from the Yandex Music app then
-                # feels near-instant instead of the 2-3 s preload tear-down
-                # the cmd_stop-based pause used to cost. The loop has no
-                # explicit deadline: as long as `_stream_stop_event` stays
-                # unset (`_clear_active_player` / `unload` are the only
-                # setters) and Ynison keeps reporting our track paused, we
-                # keep feeding silence.
-                #
-                # While paused, also freeze the UI seek bar by holding
-                # `_stream_metadata.elapsed_time` at the pause position and
-                # advancing `elapsed_time_last_updated` to "now" every
-                # iteration. MA computes `corrected_elapsed_time =
-                # elapsed_time + (now - elapsed_time_last_updated)`. By
-                # keeping the gap at zero we make the extrapolation a
-                # constant — the seek bar visually freezes. This is the
-                # only pause-state signal the AudioSource model exposes
-                # to a plugin (per upstream Spotify Connect's note in
-                # `__init__.py:904-911`); the player/queue PlaybackState
-                # itself stays PLAYING because MA short-circuits any pause
-                # we try to push back into `cmd_pause` / `queue.pause`.
+                # External pause has already been routed through
+                # `_pause_playback`, which set `_stream_stop_event` and
+                # called `cmd_stop`. The outer-loop guard above notices
+                # the stop event on the next iteration and ends the
+                # generator cleanly. AriaCast pattern — see
+                # `_pause_playback` docstring for the trade-off.
                 if self._ynison.state.is_paused:
-                    frame_size = (session_fmt.bit_depth // 8) * session_fmt.channels
-                    chunk_ms = 100
-                    samples_per_chunk = session_fmt.sample_rate * chunk_ms // 1000
-                    silence = b"\x00" * (samples_per_chunk * frame_size)
-                    chunk_timeout = chunk_ms / 1000
-                    frozen_elapsed_s = (
-                        self._ynison.state.progress_ms // 1000
-                        if self._ynison.state.progress_ms
-                        else self._streaming_progress_ms // 1000
-                    )
-                    # Push the frozen metadata to the queue's snapshot every
-                    # second. Mutating `_stream_metadata` in-place is not
-                    # enough — MA reads `current_item.streamdetails.stream_metadata`
-                    # which is a *copy* captured at stream-start time. Without
-                    # this explicit republish, the bare ALSA player's
-                    # heartbeat report (which keeps reporting elapsed_time
-                    # ticking forward because we are still yielding bytes
-                    # into its buffer) wins in `on_player_elapsed_time_corrected`
-                    # → `player_queues._handle_player_elapsed_time` overwrites
-                    # `queue.elapsed_time` and the UI seek bar keeps moving.
-                    last_metadata_push = 0.0
-                    while (
-                        not self._stream_stop_event.is_set()
-                        and (
-                            not had_claim
-                            or (
-                                self._in_use_by_queue == player_id
-                                and self._active_session_id == captured_session_id
-                            )
-                        )
-                        and self._ynison
-                        and self._ynison.state.current_track_id == track_id
-                        and self._ynison.state.is_paused
-                    ):
-                        yield silence
-                        # Freeze the metadata extrapolation each tick.
-                        self._stream_metadata.elapsed_time = frozen_elapsed_s
-                        now_t = time.time()
-                        self._stream_metadata.elapsed_time_last_updated = now_t
-                        # Republish to the queue's streamdetails snapshot at
-                        # most once per second — frequent enough to overwrite
-                        # the player's heartbeat tick, cheap enough not to
-                        # spam the websocket.
-                        if self._in_use_by_queue and now_t - last_metadata_push >= 1.0:
-                            try:
-                                self.mass.streams.update_stream_metadata(
-                                    self._in_use_by_queue,
-                                    AUDIO_SOURCE_ID,
-                                    self.instance_id,
-                                    self._stream_metadata,
-                                )
-                            except Exception:
-                                self.logger.debug(
-                                    "update_stream_metadata failed during pause",
-                                    exc_info=True,
-                                )
-                            last_metadata_push = now_t
-                        with suppress(TimeoutError):
-                            await asyncio.wait_for(
-                                self._track_changed_event.wait(),
-                                timeout=chunk_timeout,
-                            )
-                        self._track_changed_event.clear()
-                    # Same-track unpause: seed `_seek_position_ms` from
-                    # Ynison's reported progress so the next iteration
-                    # streams from the correct offset. Also covers a
-                    # paused-state seek (user dragged the seek bar in the
-                    # Yandex Music app while paused). Track changes or
-                    # stop signals fall through without seeding — the
-                    # outer loop will re-evaluate and pick the new track.
-                    if (
-                        self._ynison
-                        and self._ynison.state.current_track_id == track_id
-                        and not self._ynison.state.is_paused
-                    ):
-                        # mypy narrows `is_paused` (a regular bool property)
-                        # to `Literal[True]` after the while-loop's truthy
-                        # exit chain — that's wrong, the property is read
-                        # afresh from `player_state`, so the line is
-                        # reachable on unpause.
-                        self._seek_position_ms = self._ynison.state.progress_ms  # type: ignore[unreachable]
-                    continue
+                    return
 
                 if not self._yandex_provider:
                     self.logger.warning(
@@ -562,11 +453,6 @@ class YandexYnisonProvider(PluginProvider):
                     if (
                         self._track_changed_event.is_set()
                         or self._stream_stop_event.is_set()
-                        # Pause arrived mid-track: exit the inner stream so
-                        # the outer loop's silence keep-alive branch takes
-                        # over instead of continuing to pump real audio that
-                        # would just back-pressure MA's buffer.
-                        or (self._ynison is not None and self._ynison.state.is_paused)
                         or (
                             had_claim
                             and (
@@ -575,6 +461,10 @@ class YandexYnisonProvider(PluginProvider):
                             )
                         )
                     ):
+                        # Note: external pause routes through `_pause_playback`
+                        # → `_stream_stop_event.set()` → this break fires via
+                        # the stop-event guard. No separate `is_paused` check
+                        # needed in the chunk loop.
                         break
 
                 # Align to PCM frame boundary — prevents misalignment in MA's
@@ -977,18 +867,11 @@ class YandexYnisonProvider(PluginProvider):
             self.logger.warning("Ynison active on our device but no MA player available")
             return
 
-        # Unpause edge: nothing to do at the MA player/queue level. We
-        # never paused MA (see `_pause_playback` — the AudioSource model
-        # short-circuits any cmd_pause / queue.pause we issue back to our
-        # own `on_source_control`, so MA's queue/player state never flipped
-        # in the first place). The silence keep-alive loop in
-        # `get_audio_stream` exits on `_ynison.state.is_paused == False`
-        # and the streaming branch resumes from the seeded position;
-        # MA never had a "paused" view to undo. The `_paused_at_player`
-        # flag stays around as a no-op marker for diagnostics.
-        self._paused_at_player = False
-
-        # Detect resume after pause: stream was stopped but player still associated
+        # Detect resume after pause / fresh start: `_pause_playback` set
+        # `_stream_stop_event` on the previous external pause, so the
+        # `needs_reselect` branch below will fire `play_media` again and
+        # MA will spin up a fresh stream (the AriaCast pattern's resume
+        # cost: ~2-3 s preload + ffmpeg start-up).
         needs_reselect = self._stream_stop_event.is_set()
         self._stream_stop_event.clear()
 
@@ -1197,49 +1080,50 @@ class YandexYnisonProvider(PluginProvider):
         )
 
     async def _pause_playback(self) -> None:
-        """Handle pause — drive the MA player to PAUSED, keep the stream live.
+        """Handle external pause — release the player so MA's UI is honest.
 
-        Two coordinated signals do the work:
+        Follows the AriaCast Receiver pattern from upstream
+        (``music_assistant/providers/ariacast_receiver/__init__.py:481-490``):
+        on a pause that originates outside MA, call ``cmd_stop`` on the
+        active queue. That:
 
-        1. ``mass.players.cmd_pause(player_id)`` — tells MA's player state
-           machine to flip to PAUSED. Without this MA still considers the
-           player as PLAYING and the UI elapsed-time keeps ticking forward
-           (StreamMetadata does not carry an `is_paused` flag — pause is a
-           player-state concept, not a stream-bytes concept).
-        2. The silence keep-alive loop in ``get_audio_stream`` — yields PCM
-           zeros into the active stream while paused so MA's outer buffer
-           and the player connection stay alive without replaying pre-pause
-           audio on resume. (A pure cmd_pause without silence would leave
-           the buffer full of pre-pause audio; on cmd_play the user would
-           hear ~3 s of replayed pre-pause audio before fresh audio caught
-           up.)
+        - Flips ``player.state.playback_state`` to IDLE (the only
+          player-state mechanism the AudioSource model exposes — any
+          ``cmd_pause`` / ``queue.pause`` short-circuits back to our
+          ``on_source_control(PAUSE)`` and never touches MA state).
+        - Tears down the ``get_audio_stream`` generator cleanly via the
+          stream_stop_event the streams controller observes.
+        - Triggers ``on_source_unselected`` so ``_in_use_by_queue`` and
+          ``_active_session_id`` clear correctly.
 
-        We deliberately do NOT:
-        - set ``_stream_stop_event`` — that is reserved for permanent
-          teardown (``_clear_active_player``, ``unload``);
-        - call ``mass.players.cmd_stop`` — that drains the player and forces
-          a full ``play_media → preload → ffmpeg restart`` cycle on resume
-          (the original 2-3 s pause-resume cost we are eliminating).
+        The trade-off — accepted explicitly: a resume from the Yandex
+        Music app then has to redo ``play_media → preload → ffmpeg
+        restart → buffer fill``, costing roughly 2-3 s of inaudible time
+        before audio resumes. The alternative (silence keep-alive) kept
+        resume instant but left MA's player/queue PlaybackState stuck on
+        PLAYING with a ticking progress bar — a UX failure mode the user
+        explicitly rejected over the latency. Spotify Connect upstream
+        documents the same dilemma; AriaCast picks correctness, we match.
+
+        ``_active_player_id`` is preserved so the resume edge in
+        ``_activate_playback`` reclaims the same player via
+        ``play_media`` without re-running the auto-select heuristic
+        (``needs_reselect`` becomes True because we set the stream-stop
+        event here).
         """
-        # MA's AudioSource model has no first-class "paused" player-state
-        # for plugin-owned audio: `mass.players.cmd_pause` / `cmd_play` and
-        # `mass.player_queues.pause` / `play` short-circuit back to our
-        # `on_source_control(PAUSE)` (controller.py `_handle_cmd_pause` ->
-        # AudioSource branch -> plugin -> return without touching player or
-        # queue state). The upstream Spotify Connect provider documents
-        # this explicitly in its `__init__.py`:
-        #   "pause is rendered by the queue's seek bar freezing
-        #   (stream_metadata.elapsed_time stops advancing)"
-        # So all we do here is freeze metadata extrapolation. The silence
-        # keep-alive loop in `get_audio_stream` does the heavy lifting:
-        # it keeps yielding zero PCM and ticks `elapsed_time_last_updated`
-        # forward with `elapsed_time` held constant, so MA's
-        # `corrected_elapsed_time = elapsed_time + (now - last_updated)`
-        # comes out to the frozen value. We do not touch `cmd_pause` /
-        # `player_queues.pause` from here at all — those produce the
-        # infinite redirect loop described above and never flip any state.
-        if self._in_use_by_queue:
-            self.mass.players.trigger_player_update(self._in_use_by_queue)
+        target = self._in_use_by_queue
+        if not target:
+            self.logger.info("Pause requested but no active queue (_in_use_by_queue is None)")
+            return
+        self.logger.info("Pause: cmd_stop(%s) — release player so MA UI flips to IDLE", target)
+        # Exit the audio generator promptly. The while-loop guard at the
+        # top of get_audio_stream notices and ends; the finally clause
+        # runs and on_source_unselected clears the lock.
+        self._stream_stop_event.set()
+        try:
+            await self.mass.players.cmd_stop(target)
+        except Exception:
+            self.logger.debug("cmd_stop failed for %s on pause", target, exc_info=True)
 
     # ------------------------------------------------------------------
     # Player selection
@@ -1455,7 +1339,6 @@ class YandexYnisonProvider(PluginProvider):
         self._streaming_progress_ms = 0
         self._prefetched_list = None
         self._command_idempotency.clear()
-        self._paused_at_player = False
         if self._prefetch_task and not self._prefetch_task.done():
             self._prefetch_task.cancel()
 

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -236,10 +236,8 @@ class YandexYnisonProvider(PluginProvider):
         # state-handler twice in quick succession.
         self._command_idempotency: dict[tuple[str, str | None], float] = {}
 
-        # Explicit "we paused via cmd_stop, expect resume" marker. The
-        # resume edge reads this alongside `_stream_stop_event`; an
-        # explicit flag survives if a future code path clears the
-        # event (e.g. a new generator session arming itself).
+        # "We paused via cmd_stop, expect resume" — survives a stray
+        # `_stream_stop_event` clear independent of the stop signal.
         self._paused: bool = False
 
     # ------------------------------------------------------------------
@@ -395,14 +393,9 @@ class YandexYnisonProvider(PluginProvider):
 
         try:
             while not self._stream_stop_event.is_set() and (
-                # Preload path: no claim was active at entry — drive the loop
-                # purely off Ynison state and the stop event. on_source_selected
-                # may fire later; it doesn't disqualify us mid-stream.
-                not had_claim
-                or (
-                    self._in_use_by_queue == player_id
-                    and self._active_session_id == captured_session_id
-                )
+                # Preload path: no claim was active at entry — drive the
+                # loop purely off Ynison state and the stop event.
+                not had_claim or not self._session_lost(player_id, captured_session_id)
             ):
                 if not self._ynison or not self._ynison.state.current_track_id:
                     # Wait for a track to appear
@@ -419,8 +412,7 @@ class YandexYnisonProvider(PluginProvider):
                 track_id = self._ynison.state.current_track_id
                 self._current_streaming_track_id = track_id
 
-                # `_pause_playback` already set the stop event and
-                # released the player; the generator exits.
+                # `_pause_playback` set the stop event; finalize.
                 if self._ynison.state.is_paused:
                     return
 
@@ -453,18 +445,8 @@ class YandexYnisonProvider(PluginProvider):
                     if (
                         self._track_changed_event.is_set()
                         or self._stream_stop_event.is_set()
-                        or (
-                            had_claim
-                            and (
-                                self._in_use_by_queue != player_id
-                                or self._active_session_id != captured_session_id
-                            )
-                        )
+                        or (had_claim and self._session_lost(player_id, captured_session_id))
                     ):
-                        # Note: external pause routes through `_pause_playback`
-                        # → `_stream_stop_event.set()` → this break fires via
-                        # the stop-event guard. No separate `is_paused` check
-                        # needed in the chunk loop.
                         break
 
                 # Align to PCM frame boundary — prevents misalignment in MA's
@@ -488,9 +470,8 @@ class YandexYnisonProvider(PluginProvider):
                 # interrupted track makes Yandex auto-advance the queue —
                 # surfaces as an unwanted skip on pause / handoff.
                 broke_for_pause = self._ynison is not None and self._ynison.state.is_paused
-                broke_for_session_change = had_claim and (
-                    self._in_use_by_queue != player_id
-                    or self._active_session_id != captured_session_id
+                broke_for_session_change = had_claim and self._session_lost(
+                    player_id, captured_session_id
                 )
                 natural_end = (
                     not self._track_changed_event.is_set()
@@ -516,11 +497,7 @@ class YandexYnisonProvider(PluginProvider):
             # generator's teardown would otherwise clobber the new session's
             # claim. `had_claim` keeps the preload path from touching the lock
             # at all (no claim ever existed to release).
-            if (
-                had_claim
-                and self._in_use_by_queue == player_id
-                and self._active_session_id == captured_session_id
-            ):
+            if had_claim and not self._session_lost(player_id, captured_session_id):
                 self._in_use_by_queue = None
             self._current_streaming_track_id = None
 
@@ -571,16 +548,10 @@ class YandexYnisonProvider(PluginProvider):
         ``get_audio_stream()`` session.  Falls back to the current
         ``_normalized_params`` when called outside a session.
         """
-        # Mark this fetch as in-flight to yandex_music: the user has
-        # explicitly tried to start (or just continue) a track via Ynison
-        # and we are inside the audio generator that owes them PCM. If a
-        # captcha cooldown is engaged on the "default" kind from some
-        # unrelated past 429, dropping the stream is strictly worse than
-        # risking another captcha trip — same trade-off yandex_music's own
-        # `BYPASS_THROTTLER` path makes for stream-URL refreshes mid-track.
-        # The prefetch path (`_prefetch_format_for_track`) is intentionally
-        # NOT bypassed: it has a 2.5 s timeout and skipping it on cooldown
-        # only costs a missed auto-rate hint, not the whole playback.
+        # In-flight stream fetch outranks unrelated 429 cooldowns:
+        # dropping a stream the user is actively trying to play is
+        # worse than risking another captcha. Prefetch deliberately
+        # stays throttled (see `_prefetch_format_for_track`).
         bypass_token = BYPASS_THROTTLER.set(True)
         try:
             stream_details = await self._get_stream_details_with_retry(track_id)
@@ -884,9 +855,8 @@ class YandexYnisonProvider(PluginProvider):
             # the cached format is still correct for that case.
             upcoming = state.current_track_id
             switching_player = self._active_player_id != target_player_id
-            new_for_us = upcoming and upcoming != self._current_streaming_track_id
             self._active_player_id = target_player_id
-            if upcoming and (switching_player or new_for_us):
+            if upcoming and (switching_player or upcoming != self._current_streaming_track_id):
                 await self._prefetch_format_for_track(upcoming)
             self.mass.create_task(
                 self.mass.player_queues.play_media(target_player_id, str(self._audio_source.uri))
@@ -1083,7 +1053,10 @@ class YandexYnisonProvider(PluginProvider):
         to IDLE for an AudioSource queue item; ``cmd_pause`` and
         ``queue.pause`` both short-circuit back to ``on_source_control``
         and leave MA's state untouched. Pattern matches upstream
-        ``AriaCastReceiver._handle_playback_state_update``.
+        ``AriaCastReceiver._handle_playback_state_update``. Resume
+        re-runs ``play_media`` (preload + ffmpeg startup) so it costs
+        a few seconds — the alternative kept resume instant but left
+        MA's UI stuck on PLAYING.
         """
         target = self._in_use_by_queue
         if not target:
@@ -1221,6 +1194,14 @@ class YandexYnisonProvider(PluginProvider):
         self._active_session_id = None
         if self._in_use_by_queue == queue_id:
             self._in_use_by_queue = None
+
+    def _session_lost(self, player_id: str, session_id: str | None) -> bool:
+        """Return ``True`` when our claim no longer matches the live session.
+
+        :param player_id: Queue id captured at generator entry.
+        :param session_id: ``_active_session_id`` captured at generator entry.
+        """
+        return self._in_use_by_queue != player_id or self._active_session_id != session_id
 
     def _idempotent(self, action: str, key: str | None) -> bool:
         """Return ``True`` if ``(action, key)`` was not seen within the TTL window.

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -533,9 +533,25 @@ class YandexYnisonProvider(PluginProvider):
                 if self._stream_stop_event.is_set():
                     break
 
-                # Track finished naturally — signal completion to Ynison.
-                # Yandex controls the queue; we just wait for the next track.
-                if not self._track_changed_event.is_set() and self._ynison:
+                # Differentiate "track finished naturally" from "inner loop
+                # broke out early". The inner chunk loop's break conditions
+                # cover: track change, stop event, pause, and same-queue
+                # reconnect/session supersede. If ANY of those triggered, we
+                # must NOT signal completion — doing so would tell Ynison the
+                # old track ended and Yandex would advance the queue,
+                # producing the "press pause, next track starts" bug.
+                broke_for_pause = self._ynison is not None and self._ynison.state.is_paused
+                broke_for_session_change = had_claim and (
+                    self._in_use_by_queue != player_id
+                    or self._active_session_id != captured_session_id
+                )
+                natural_end = (
+                    not self._track_changed_event.is_set()
+                    and not broke_for_pause
+                    and not broke_for_session_change
+                    and self._ynison is not None
+                )
+                if natural_end:
                     self.logger.info("Track %s finished, advancing to next", track_id)
                     await self._signal_track_completion()
                     if not await self._wait_for_track_change(track_id):

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -436,12 +436,30 @@ class YandexYnisonProvider(PluginProvider):
                 # unset (`_clear_active_player` / `unload` are the only
                 # setters) and Ynison keeps reporting our track paused, we
                 # keep feeding silence.
+                #
+                # While paused, also freeze the UI seek bar by holding
+                # `_stream_metadata.elapsed_time` at the pause position and
+                # advancing `elapsed_time_last_updated` to "now" every
+                # iteration. MA computes `corrected_elapsed_time =
+                # elapsed_time + (now - elapsed_time_last_updated)`. By
+                # keeping the gap at zero we make the extrapolation a
+                # constant — the seek bar visually freezes. This is the
+                # only pause-state signal the AudioSource model exposes
+                # to a plugin (per upstream Spotify Connect's note in
+                # `__init__.py:904-911`); the player/queue PlaybackState
+                # itself stays PLAYING because MA short-circuits any pause
+                # we try to push back into `cmd_pause` / `queue.pause`.
                 if self._ynison.state.is_paused:
                     frame_size = (session_fmt.bit_depth // 8) * session_fmt.channels
                     chunk_ms = 100
                     samples_per_chunk = session_fmt.sample_rate * chunk_ms // 1000
                     silence = b"\x00" * (samples_per_chunk * frame_size)
                     chunk_timeout = chunk_ms / 1000
+                    frozen_elapsed_s = (
+                        self._ynison.state.progress_ms // 1000
+                        if self._ynison.state.progress_ms
+                        else self._streaming_progress_ms // 1000
+                    )
                     while (
                         not self._stream_stop_event.is_set()
                         and (
@@ -456,6 +474,9 @@ class YandexYnisonProvider(PluginProvider):
                         and self._ynison.state.is_paused
                     ):
                         yield silence
+                        # Freeze the metadata extrapolation each tick.
+                        self._stream_metadata.elapsed_time = frozen_elapsed_s
+                        self._stream_metadata.elapsed_time_last_updated = time.time()
                         with suppress(TimeoutError):
                             await asyncio.wait_for(
                                 self._track_changed_event.wait(),
@@ -926,31 +947,16 @@ class YandexYnisonProvider(PluginProvider):
             self.logger.warning("Ynison active on our device but no MA player available")
             return
 
-        # Unpause edge: we are entering this method because Ynison reports
-        # the device active AND not paused. If `_paused_at_player` is set,
-        # we previously drove the MA QUEUE into PAUSED via
-        # `mass.player_queues.pause(queue_id)` — release it via
-        # `player_queues.play(queue_id)` so the queue's playback_state
-        # flips back, the player resumes draining the silence back-fill
-        # the keep-alive loop produced, and real audio continues. The
-        # queue id is the one MA handed us in `on_source_selected`
-        # (`_in_use_by_queue`); MUST match the id we paused on, otherwise
-        # the queue stays paused. Clear the flag unconditionally so a
-        # failure does not strand us in a "queue paused but flag stuck"
-        # state.
-        if self._paused_at_player:
-            self._paused_at_player = False
-            queue_id = self._in_use_by_queue
-            if queue_id:
-                self.logger.info("Unpause: player_queues.play(%s)", queue_id)
-                try:
-                    await self.mass.player_queues.play(queue_id)
-                except Exception:
-                    self.logger.warning(
-                        "player_queues.play failed for %s during unpause",
-                        queue_id,
-                        exc_info=True,
-                    )
+        # Unpause edge: nothing to do at the MA player/queue level. We
+        # never paused MA (see `_pause_playback` — the AudioSource model
+        # short-circuits any cmd_pause / queue.pause we issue back to our
+        # own `on_source_control`, so MA's queue/player state never flipped
+        # in the first place). The silence keep-alive loop in
+        # `get_audio_stream` exits on `_ynison.state.is_paused == False`
+        # and the streaming branch resumes from the seeded position;
+        # MA never had a "paused" view to undo. The `_paused_at_player`
+        # flag stays around as a no-op marker for diagnostics.
+        self._paused_at_player = False
 
         # Detect resume after pause: stream was stopped but player still associated
         needs_reselect = self._stream_stop_event.is_set()
@@ -1185,31 +1191,25 @@ class YandexYnisonProvider(PluginProvider):
           a full ``play_media → preload → ffmpeg restart`` cycle on resume
           (the original 2-3 s pause-resume cost we are eliminating).
         """
-        # Drive the QUEUE, not the player. MA's UI for an AudioSource item
-        # reads playback_state from the queue that owns it, not from the
-        # underlying player. `mass.players.cmd_pause(player_id)` is a thin
-        # redirect to `mass.player_queues.pause(queue_id)` — it looks up the
-        # queue that the player belongs to and forwards. When a protocol
-        # bridge is involved (Local Audio Out → Sendspin `spb_*` wrapping
-        # the bare ALSA UUID), our streaming player is the bridge while the
-        # queue we hold a claim on belongs to the bare UUID. `cmd_pause`
-        # against the bridge searches for a queue keyed by the bridge id
-        # and finds either nothing or the wrong queue — the stream
-        # eventually stops because the bridge tears down the audio path,
-        # but our queue's playback_state never flips and the UI keeps
-        # ticking. Address both halves at the source: call
-        # `player_queues.pause(_in_use_by_queue)` directly. `_in_use_by_queue`
-        # IS the queue_id MA handed us in `on_source_selected`.
-        queue_id = self._in_use_by_queue
-        if not queue_id:
-            self.logger.info("Pause requested but no active queue (_in_use_by_queue is None)")
-            return
-        self.logger.info("Pause: player_queues.pause(%s)", queue_id)
-        try:
-            await self.mass.player_queues.pause(queue_id)
-        except Exception:
-            self.logger.warning("player_queues.pause failed for %s", queue_id, exc_info=True)
-        self._paused_at_player = True
+        # MA's AudioSource model has no first-class "paused" player-state
+        # for plugin-owned audio: `mass.players.cmd_pause` / `cmd_play` and
+        # `mass.player_queues.pause` / `play` short-circuit back to our
+        # `on_source_control(PAUSE)` (controller.py `_handle_cmd_pause` ->
+        # AudioSource branch -> plugin -> return without touching player or
+        # queue state). The upstream Spotify Connect provider documents
+        # this explicitly in its `__init__.py`:
+        #   "pause is rendered by the queue's seek bar freezing
+        #   (stream_metadata.elapsed_time stops advancing)"
+        # So all we do here is freeze metadata extrapolation. The silence
+        # keep-alive loop in `get_audio_stream` does the heavy lifting:
+        # it keeps yielding zero PCM and ticks `elapsed_time_last_updated`
+        # forward with `elapsed_time` held constant, so MA's
+        # `corrected_elapsed_time = elapsed_time + (now - last_updated)`
+        # comes out to the frozen value. We do not touch `cmd_pause` /
+        # `player_queues.pause` from here at all — those produce the
+        # infinite redirect loop described above and never flip any state.
+        if self._in_use_by_queue:
+            self.mass.players.trigger_player_update(self._in_use_by_queue)
 
     # ------------------------------------------------------------------
     # Player selection

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -30,7 +30,7 @@ from music_assistant_models.streamdetails import StreamDetails, StreamMetadata
 from ya_passport_auth import SecretStr
 
 from music_assistant.helpers.ffmpeg import get_ffmpeg_stream
-from music_assistant.helpers.throttle_retry import ThrottlerManager
+from music_assistant.helpers.throttle_retry import BYPASS_THROTTLER, ThrottlerManager
 from music_assistant.models.plugin import PluginProvider
 
 from .auth import refresh_music_token
@@ -633,12 +633,25 @@ class YandexYnisonProvider(PluginProvider):
         ``get_audio_stream()`` session.  Falls back to the current
         ``_normalized_params`` when called outside a session.
         """
+        # Mark this fetch as in-flight to yandex_music: the user has
+        # explicitly tried to start (or just continue) a track via Ynison
+        # and we are inside the audio generator that owes them PCM. If a
+        # captcha cooldown is engaged on the "default" kind from some
+        # unrelated past 429, dropping the stream is strictly worse than
+        # risking another captcha trip — same trade-off yandex_music's own
+        # `BYPASS_THROTTLER` path makes for stream-URL refreshes mid-track.
+        # The prefetch path (`_prefetch_format_for_track`) is intentionally
+        # NOT bypassed: it has a 2.5 s timeout and skipping it on cooldown
+        # only costs a missed auto-rate hint, not the whole playback.
+        bypass_token = BYPASS_THROTTLER.set(True)
         try:
             stream_details = await self._get_stream_details_with_retry(track_id)
         except Exception:
             self.logger.exception("Failed to get stream details for track %s", track_id)
             self._stream_stop_event.set()
             return
+        finally:
+            BYPASS_THROTTLER.reset(bypass_token)
 
         # Re-capture the provider after the above await: _yandex_provider may
         # have flipped to None while we were fetching stream details.  Using
@@ -888,14 +901,22 @@ class YandexYnisonProvider(PluginProvider):
             return
 
         if is_our_device and not state.is_paused:
+            self.logger.info(
+                "Ynison → playing (track=%s progress=%dms)", track_id, state.progress_ms
+            )
             # Pre-fetch next batch when playing second-to-last track
             self._maybe_prefetch(current_index, playable_list, entity_id, entity_type)
             await self._activate_playback(state)
         elif is_our_device and state.is_paused:
-            # Our device but paused — stop player, keep association
+            self.logger.info(
+                "Ynison → paused (track=%s progress=%dms)", track_id, state.progress_ms
+            )
             await self._pause_playback()
         elif self._in_use_by_queue:
-            # Active device switched away — fully release player
+            self.logger.info(
+                "Ynison → other device active (was=%s), clearing",
+                state.active_device_id,
+            )
             self._clear_active_player()
 
     async def _activate_playback(self, state: YnisonState) -> None:  # noqa: PLR0915
@@ -914,10 +935,11 @@ class YandexYnisonProvider(PluginProvider):
         # does not strand us in a "paused at player but flag stuck" state.
         if self._paused_at_player:
             self._paused_at_player = False
+            self.logger.info("Unpause: cmd_play(%s)", target_player_id)
             try:
                 await self.mass.players.cmd_play(target_player_id)
             except Exception:
-                self.logger.debug(
+                self.logger.warning(
                     "cmd_play failed for %s during unpause", target_player_id, exc_info=True
                 )
 
@@ -1152,11 +1174,13 @@ class YandexYnisonProvider(PluginProvider):
         """
         player_id = self._in_use_by_queue
         if not player_id:
+            self.logger.info("Pause requested but no active player (_in_use_by_queue is None)")
             return
+        self.logger.info("Pause: cmd_pause(%s)", player_id)
         try:
             await self.mass.players.cmd_pause(player_id)
         except Exception:
-            self.logger.debug("cmd_pause failed for %s", player_id, exc_info=True)
+            self.logger.warning("cmd_pause failed for %s", player_id, exc_info=True)
         self._paused_at_player = True
 
     # ------------------------------------------------------------------

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -460,6 +460,17 @@ class YandexYnisonProvider(PluginProvider):
                         if self._ynison.state.progress_ms
                         else self._streaming_progress_ms // 1000
                     )
+                    # Push the frozen metadata to the queue's snapshot every
+                    # second. Mutating `_stream_metadata` in-place is not
+                    # enough — MA reads `current_item.streamdetails.stream_metadata`
+                    # which is a *copy* captured at stream-start time. Without
+                    # this explicit republish, the bare ALSA player's
+                    # heartbeat report (which keeps reporting elapsed_time
+                    # ticking forward because we are still yielding bytes
+                    # into its buffer) wins in `on_player_elapsed_time_corrected`
+                    # → `player_queues._handle_player_elapsed_time` overwrites
+                    # `queue.elapsed_time` and the UI seek bar keeps moving.
+                    last_metadata_push = 0.0
                     while (
                         not self._stream_stop_event.is_set()
                         and (
@@ -476,7 +487,26 @@ class YandexYnisonProvider(PluginProvider):
                         yield silence
                         # Freeze the metadata extrapolation each tick.
                         self._stream_metadata.elapsed_time = frozen_elapsed_s
-                        self._stream_metadata.elapsed_time_last_updated = time.time()
+                        now_t = time.time()
+                        self._stream_metadata.elapsed_time_last_updated = now_t
+                        # Republish to the queue's streamdetails snapshot at
+                        # most once per second — frequent enough to overwrite
+                        # the player's heartbeat tick, cheap enough not to
+                        # spam the websocket.
+                        if self._in_use_by_queue and now_t - last_metadata_push >= 1.0:
+                            try:
+                                self.mass.streams.update_stream_metadata(
+                                    self._in_use_by_queue,
+                                    AUDIO_SOURCE_ID,
+                                    self.instance_id,
+                                    self._stream_metadata,
+                                )
+                            except Exception:
+                                self.logger.debug(
+                                    "update_stream_metadata failed during pause",
+                                    exc_info=True,
+                                )
+                            last_metadata_push = now_t
                         with suppress(TimeoutError):
                             await asyncio.wait_for(
                                 self._track_changed_event.wait(),

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -1089,8 +1089,12 @@ class YandexYnisonProvider(PluginProvider):
                 )
         meta.elapsed_time = seek_ms // 1000 if seek_ms else 0
         meta.elapsed_time_last_updated = time.time()
-        if self._in_use_by_queue:
-            self.mass.players.trigger_player_update(self._in_use_by_queue, force_update=True)
+        # `trigger_player_update` expects a player_id; `_in_use_by_queue` is
+        # a queue identifier which only happens to coincide with player_id
+        # when there is no protocol bridge. Use `_active_player_id` — the
+        # real player wrapping our stream (bridge if any).
+        if self._active_player_id:
+            self.mass.players.trigger_player_update(self._active_player_id, force_update=True)
 
     async def _send_progress_to_ynison(
         self, progress_ms: int, duration_ms: int, paused: bool
@@ -1172,9 +1176,23 @@ class YandexYnisonProvider(PluginProvider):
           a full ``play_media → preload → ffmpeg restart`` cycle on resume
           (the original 2-3 s pause-resume cost we are eliminating).
         """
-        player_id = self._in_use_by_queue
+        # Use `_active_player_id` (the actual player consuming our stream),
+        # NOT `_in_use_by_queue`. The latter is a queue identifier set by
+        # `on_source_selected`; MA's player-queues and player controllers
+        # share an id convention IN PRINCIPLE, but bridge players (e.g.
+        # Local Audio Out → Sendspin protocol bridge, registered as
+        # `spb_*` wrapping the bare ALSA player UUID) break it. queue_id
+        # is the bare UUID, the bridge is the player that actually owns
+        # the stream. cmd_pause on the bare UUID gets routed to the bare
+        # device successfully (audio stops) but the bridge's state machine
+        # — which the MA UI consults — never flips to PAUSED, so the UI
+        # keeps saying "playing" with a ticking progress bar.
+        # `_active_player_id` is the bridge, set by `on_source_selected`
+        # from its `player_id` parameter, and matches what `cmd_play` uses
+        # in `_activate_playback` on the unpause edge.
+        player_id = self._active_player_id
         if not player_id:
-            self.logger.info("Pause requested but no active player (_in_use_by_queue is None)")
+            self.logger.info("Pause requested but no active player (_active_player_id is None)")
             return
         self.logger.info("Pause: cmd_pause(%s)", player_id)
         try:

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -114,12 +114,10 @@ _VALID_BIT_DEPTHS: frozenset[str] = frozenset({"16", "24"})
 class YandexYnisonProvider(PluginProvider):
     """Implementation of the Yandex Music Connect (Ynison) Plugin."""
 
-    # Upstream MA's audio_analysis providers (Loudness Analysis, Smart Fades)
-    # branch on `provider.is_streaming_provider` to decide whether to run an
-    # analysis pass. The `PluginProvider` base class does not declare the
-    # attribute, so without this class-level default the analysers raise
-    # `AttributeError` once per track. We're a live source — analysing each
-    # transient track buys nothing — so opt out explicitly.
+    # PluginProvider base does not declare `is_streaming_provider`; MA's
+    # audio-analysis path raises AttributeError for live sources without
+    # an explicit opt-out. Analysing transient external-source tracks
+    # buys nothing.
     is_streaming_provider: bool = False
 
     @property
@@ -237,6 +235,12 @@ class YandexYnisonProvider(PluginProvider):
         # against echo-storms where the same Ynison broadcast lands on our
         # state-handler twice in quick succession.
         self._command_idempotency: dict[tuple[str, str | None], float] = {}
+
+        # Explicit "we paused via cmd_stop, expect resume" marker. The
+        # resume edge reads this alongside `_stream_stop_event`; an
+        # explicit flag survives if a future code path clears the
+        # event (e.g. a new generator session arming itself).
+        self._paused: bool = False
 
     # ------------------------------------------------------------------
     # Provider lifecycle
@@ -415,12 +419,8 @@ class YandexYnisonProvider(PluginProvider):
                 track_id = self._ynison.state.current_track_id
                 self._current_streaming_track_id = track_id
 
-                # External pause has already been routed through
-                # `_pause_playback`, which set `_stream_stop_event` and
-                # called `cmd_stop`. The outer-loop guard above notices
-                # the stop event on the next iteration and ends the
-                # generator cleanly. AriaCast pattern — see
-                # `_pause_playback` docstring for the trade-off.
+                # `_pause_playback` already set the stop event and
+                # released the player; the generator exits.
                 if self._ynison.state.is_paused:
                     return
 
@@ -484,12 +484,9 @@ class YandexYnisonProvider(PluginProvider):
                     break
 
                 # Differentiate "track finished naturally" from "inner loop
-                # broke out early". The inner chunk loop's break conditions
-                # cover: track change, stop event, pause, and same-queue
-                # reconnect/session supersede. If ANY of those triggered, we
-                # must NOT signal completion — doing so would tell Ynison the
-                # old track ended and Yandex would advance the queue,
-                # producing the "press pause, next track starts" bug.
+                # broke out early". Signalling completion on an
+                # interrupted track makes Yandex auto-advance the queue —
+                # surfaces as an unwanted skip on pause / handoff.
                 broke_for_pause = self._ynison is not None and self._ynison.state.is_paused
                 broke_for_session_change = had_claim and (
                     self._in_use_by_queue != player_id
@@ -867,13 +864,13 @@ class YandexYnisonProvider(PluginProvider):
             self.logger.warning("Ynison active on our device but no MA player available")
             return
 
-        # Detect resume after pause / fresh start: `_pause_playback` set
-        # `_stream_stop_event` on the previous external pause, so the
-        # `needs_reselect` branch below will fire `play_media` again and
-        # MA will spin up a fresh stream (the AriaCast pattern's resume
-        # cost: ~2-3 s preload + ffmpeg start-up).
-        needs_reselect = self._stream_stop_event.is_set()
+        # Resume after pause / fresh start: either signal triggers
+        # play_media below. `_paused` survives a stray stop-event
+        # clear; the stop event covers non-pause stop reasons
+        # (`_stream_track` warning branch, `_clear_active_player`).
+        needs_reselect = self._stream_stop_event.is_set() or self._paused
         self._stream_stop_event.clear()
+        self._paused = False
 
         # Start playback via the standard play_media flow if not already active.
         # Guard on _active_player_id (set immediately) rather than in_use_by_queue
@@ -1080,63 +1077,41 @@ class YandexYnisonProvider(PluginProvider):
         )
 
     async def _pause_playback(self) -> None:
-        """Handle external pause — release the player so MA's UI is honest.
+        """Release the active player on external pause.
 
-        Follows the AriaCast Receiver pattern from upstream
-        (``music_assistant/providers/ariacast_receiver/__init__.py:481-490``):
-        on a pause that originates outside MA, call ``cmd_stop`` on the
-        active queue. That:
-
-        - Flips ``player.state.playback_state`` to IDLE (the only
-          player-state mechanism the AudioSource model exposes — any
-          ``cmd_pause`` / ``queue.pause`` short-circuits back to our
-          ``on_source_control(PAUSE)`` and never touches MA state).
-        - Tears down the ``get_audio_stream`` generator cleanly via the
-          stream_stop_event the streams controller observes.
-        - Triggers ``on_source_unselected`` so ``_in_use_by_queue`` and
-          ``_active_session_id`` clear correctly.
-
-        The trade-off — accepted explicitly: a resume from the Yandex
-        Music app then has to redo ``play_media → preload → ffmpeg
-        restart → buffer fill``, costing roughly 2-3 s of inaudible time
-        before audio resumes. The alternative (silence keep-alive) kept
-        resume instant but left MA's player/queue PlaybackState stuck on
-        PLAYING with a ticking progress bar — a UX failure mode the user
-        explicitly rejected over the latency. Spotify Connect upstream
-        documents the same dilemma; AriaCast picks correctness, we match.
-
-        ``_active_player_id`` is preserved so the resume edge in
-        ``_activate_playback`` reclaims the same player via
-        ``play_media`` without re-running the auto-select heuristic
-        (``needs_reselect`` becomes True because we set the stream-stop
-        event here).
+        ``cmd_stop`` is the only mechanism that flips ``PlaybackState``
+        to IDLE for an AudioSource queue item; ``cmd_pause`` and
+        ``queue.pause`` both short-circuit back to ``on_source_control``
+        and leave MA's state untouched. Pattern matches upstream
+        ``AriaCastReceiver._handle_playback_state_update``.
         """
         target = self._in_use_by_queue
         if not target:
             self.logger.info("Pause requested but no active queue (_in_use_by_queue is None)")
             return
-        # Rewrite `_active_player_id` to the queue id BEFORE cmd_stop.
-        # `on_source_selected` had stamped `_active_player_id` with the
-        # player MA hands stream-bytes to (the Sendspin bridge `spb_*`
-        # when Local Audio Out wraps the bare ALSA UUID). MA's
-        # `player_queues.play_media` requires a queue_id, and queues live
-        # on the BARE UUID — they don't exist for `spb_*` wrappers. Once
-        # `on_source_unselected` clears `_in_use_by_queue`, the only
-        # surviving id pointer is `_active_player_id`; if it still points
-        # at the bridge, the resume edge in `_activate_playback` calls
-        # `play_media("spb_*", ...)` and MA raises
-        # `PlayerUnavailableError: Queue spb_... is not available`.
-        # Mirror AriaCast (`ariacast_receiver/__init__.py:485`).
-        self._active_player_id = target
-        self.logger.info("Pause: cmd_stop(%s) — release player so MA UI flips to IDLE", target)
-        # Exit the audio generator promptly. The while-loop guard at the
-        # top of get_audio_stream notices and ends; the finally clause
-        # runs and on_source_unselected clears the lock.
+        self.logger.info("Pause: cmd_stop(%s)", target)
+        # stop event ends the audio generator; finally clears the lock.
         self._stream_stop_event.set()
         try:
             await self.mass.players.cmd_stop(target)
         except Exception:
-            self.logger.debug("cmd_stop failed for %s on pause", target, exc_info=True)
+            # cmd_stop is the only mechanism that flips MA's PlaybackState
+            # to IDLE for an AudioSource. A silent failure here resurrects
+            # the very UX bug this code path exists to fix.
+            self.logger.warning(
+                "cmd_stop(%s) failed during external pause — MA UI may stay PLAYING",
+                target,
+                exc_info=True,
+            )
+            return
+        # Demote `_active_player_id` from the bridge MA streams to
+        # (e.g. `spb_*`) back to the queue id; queues live on the bare
+        # UUID. Without this, resume's `play_media(_active_player_id,
+        # …)` would target the bridge and raise
+        # `PlayerUnavailableError`. Post-success only so a failure
+        # path keeps the bridge id intact for the next attempt.
+        self._active_player_id = target
+        self._paused = True
 
     # ------------------------------------------------------------------
     # Player selection
@@ -1352,6 +1327,7 @@ class YandexYnisonProvider(PluginProvider):
         self._streaming_progress_ms = 0
         self._prefetched_list = None
         self._command_idempotency.clear()
+        self._paused = False
         if self._prefetch_task and not self._prefetch_task.done():
             self._prefetch_task.cancel()
 

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -238,6 +238,15 @@ class YandexYnisonProvider(PluginProvider):
         # state-handler twice in quick succession.
         self._command_idempotency: dict[tuple[str, str | None], float] = {}
 
+        # Tracks whether we have driven the MA player into PAUSED via
+        # `cmd_pause`. Paired with the silence-keepalive loop in
+        # `get_audio_stream`: cmd_pause is what makes the MA UI show paused
+        # and freezes the elapsed-time extrapolation; silence-keepalive is
+        # what keeps the stream connection alive across the pause without
+        # replaying the pre-pause buffer on resume. We flip back to PLAYING
+        # via `cmd_play` from `_activate_playback` on the unpause edge.
+        self._paused_at_player: bool = False
+
     # ------------------------------------------------------------------
     # Provider lifecycle
     # ------------------------------------------------------------------
@@ -896,6 +905,22 @@ class YandexYnisonProvider(PluginProvider):
             self.logger.warning("Ynison active on our device but no MA player available")
             return
 
+        # Unpause edge: we are entering this method because Ynison reports
+        # the device active AND not paused. If `_paused_at_player` is set,
+        # we previously drove the MA player into PAUSED via `cmd_pause` —
+        # release it via `cmd_play` so the player drains the silence
+        # back-fill that the keep-alive loop produced and resumes real
+        # audio. Clear the flag unconditionally so a failure to cmd_play
+        # does not strand us in a "paused at player but flag stuck" state.
+        if self._paused_at_player:
+            self._paused_at_player = False
+            try:
+                await self.mass.players.cmd_play(target_player_id)
+            except Exception:
+                self.logger.debug(
+                    "cmd_play failed for %s during unpause", target_player_id, exc_info=True
+                )
+
         # Detect resume after pause: stream was stopped but player still associated
         needs_reselect = self._stream_stop_event.is_set()
         self._stream_stop_event.clear()
@@ -1101,28 +1126,38 @@ class YandexYnisonProvider(PluginProvider):
         )
 
     async def _pause_playback(self) -> None:
-        """Handle pause — switch the running stream to silence keep-alive.
+        """Handle pause — drive the MA player to PAUSED, keep the stream live.
 
-        Silence keep-alive (see ``get_audio_stream``) lets the stream stay
-        open during a pause: the generator yields PCM zeros at real-time rate
-        so MA's outer buffer and the player connection survive the pause
-        without a tear-down + ``play_media`` restart on resume. Without this,
-        every pause/resume from the Yandex Music app cost 2-3 s of preload +
-        ffmpeg start-up + player-buffer fill before audio became audible
-        again.
+        Two coordinated signals do the work:
 
-        Therefore we no longer:
-        - set ``_stream_stop_event`` (would force-exit the generator),
-        - call ``mass.players.cmd_stop(player_id)`` (would drain the player).
+        1. ``mass.players.cmd_pause(player_id)`` — tells MA's player state
+           machine to flip to PAUSED. Without this MA still considers the
+           player as PLAYING and the UI elapsed-time keeps ticking forward
+           (StreamMetadata does not carry an `is_paused` flag — pause is a
+           player-state concept, not a stream-bytes concept).
+        2. The silence keep-alive loop in ``get_audio_stream`` — yields PCM
+           zeros into the active stream while paused so MA's outer buffer
+           and the player connection stay alive without replaying pre-pause
+           audio on resume. (A pure cmd_pause without silence would leave
+           the buffer full of pre-pause audio; on cmd_play the user would
+           hear ~3 s of replayed pre-pause audio before fresh audio caught
+           up.)
 
-        ``_stream_stop_event`` stays the sole responsibility of "permanent"
-        teardown paths (``_clear_active_player``, ``unload``). The generator
-        notices ``self._ynison.state.is_paused`` directly and re-routes into
-        the silence loop.
+        We deliberately do NOT:
+        - set ``_stream_stop_event`` — that is reserved for permanent
+          teardown (``_clear_active_player``, ``unload``);
+        - call ``mass.players.cmd_stop`` — that drains the player and forces
+          a full ``play_media → preload → ffmpeg restart`` cycle on resume
+          (the original 2-3 s pause-resume cost we are eliminating).
         """
         player_id = self._in_use_by_queue
-        if player_id:
-            self.mass.players.trigger_player_update(player_id)
+        if not player_id:
+            return
+        try:
+            await self.mass.players.cmd_pause(player_id)
+        except Exception:
+            self.logger.debug("cmd_pause failed for %s", player_id, exc_info=True)
+        self._paused_at_player = True
 
     # ------------------------------------------------------------------
     # Player selection
@@ -1338,6 +1373,7 @@ class YandexYnisonProvider(PluginProvider):
         self._streaming_progress_ms = 0
         self._prefetched_list = None
         self._command_idempotency.clear()
+        self._paused_at_player = False
         if self._prefetch_task and not self._prefetch_task.done():
             self._prefetch_task.cancel()
 

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -415,11 +415,24 @@ class YandexYnisonProvider(PluginProvider):
                 track_id = self._ynison.state.current_track_id
                 self._current_streaming_track_id = track_id
 
-                # Don't start streaming if Ynison reports paused — wait for resume.
-                # Poll every 1s because a same-track resume won't trigger
-                # _track_changed_event (it only fires on track change / seek).
+                # Silence keep-alive: when Ynison reports paused (whether at
+                # session start or after a mid-stream pause), yield PCM zeros
+                # at real-time rate so MA's outer buffer and the player
+                # connection stay alive. On unpause we transition straight
+                # into real audio without a play_media / preload / ffmpeg
+                # restart cycle — pause/resume from the Yandex Music app then
+                # feels near-instant instead of the 2-3 s preload tear-down
+                # the cmd_stop-based pause used to cost. The loop has no
+                # explicit deadline: as long as `_stream_stop_event` stays
+                # unset (`_clear_active_player` / `unload` are the only
+                # setters) and Ynison keeps reporting our track paused, we
+                # keep feeding silence.
                 if self._ynison.state.is_paused:
-                    pause_deadline = time.monotonic() + 30.0
+                    frame_size = (session_fmt.bit_depth // 8) * session_fmt.channels
+                    chunk_ms = 100
+                    samples_per_chunk = session_fmt.sample_rate * chunk_ms // 1000
+                    silence = b"\x00" * (samples_per_chunk * frame_size)
+                    chunk_timeout = chunk_ms / 1000
                     while (
                         not self._stream_stop_event.is_set()
                         and (
@@ -432,15 +445,32 @@ class YandexYnisonProvider(PluginProvider):
                         and self._ynison
                         and self._ynison.state.current_track_id == track_id
                         and self._ynison.state.is_paused
-                        and time.monotonic() < pause_deadline
                     ):
-                        remaining = pause_deadline - time.monotonic()
+                        yield silence
                         with suppress(TimeoutError):
                             await asyncio.wait_for(
                                 self._track_changed_event.wait(),
-                                timeout=min(1.0, remaining),
+                                timeout=chunk_timeout,
                             )
                         self._track_changed_event.clear()
+                    # Same-track unpause: seed `_seek_position_ms` from
+                    # Ynison's reported progress so the next iteration
+                    # streams from the correct offset. Also covers a
+                    # paused-state seek (user dragged the seek bar in the
+                    # Yandex Music app while paused). Track changes or
+                    # stop signals fall through without seeding — the
+                    # outer loop will re-evaluate and pick the new track.
+                    if (
+                        self._ynison
+                        and self._ynison.state.current_track_id == track_id
+                        and not self._ynison.state.is_paused
+                    ):
+                        # mypy narrows `is_paused` (a regular bool property)
+                        # to `Literal[True]` after the while-loop's truthy
+                        # exit chain — that's wrong, the property is read
+                        # afresh from `player_state`, so the line is
+                        # reachable on unpause.
+                        self._seek_position_ms = self._ynison.state.progress_ms  # type: ignore[unreachable]
                     continue
 
                 if not self._yandex_provider:
@@ -472,6 +502,11 @@ class YandexYnisonProvider(PluginProvider):
                     if (
                         self._track_changed_event.is_set()
                         or self._stream_stop_event.is_set()
+                        # Pause arrived mid-track: exit the inner stream so
+                        # the outer loop's silence keep-alive branch takes
+                        # over instead of continuing to pump real audio that
+                        # would just back-pressure MA's buffer.
+                        or (self._ynison is not None and self._ynison.state.is_paused)
                         or (
                             had_claim
                             and (
@@ -1050,26 +1085,27 @@ class YandexYnisonProvider(PluginProvider):
         )
 
     async def _pause_playback(self) -> None:
-        """Handle pause — stop streaming but keep player association for resume."""
-        paused_progress_ms = self._streaming_progress_ms
-        self._stream_stop_event.set()
-        # Preserve the last known position for same-track resume.
-        self._streaming_progress_ms = paused_progress_ms
-        # Don't pre-clear _in_use_by_queue here. Lock release is owned by the
-        # standard teardown path (the streaming generator's finally + the
-        # streams controller's on_source_unselected), which clears both the
-        # lock and the session id together under the session-id guard.
-        # Pre-clearing the lock while leaving the session id set is the
-        # double-write the session-id system was designed to prevent. Note:
-        # cmd_stop is not a guaranteed teardown trigger — if the generator
-        # is blocked on a long external poll the finally may take a while —
-        # but the worst outcome is a delayed release, not an incorrect one.
+        """Handle pause — switch the running stream to silence keep-alive.
+
+        Silence keep-alive (see ``get_audio_stream``) lets the stream stay
+        open during a pause: the generator yields PCM zeros at real-time rate
+        so MA's outer buffer and the player connection survive the pause
+        without a tear-down + ``play_media`` restart on resume. Without this,
+        every pause/resume from the Yandex Music app cost 2-3 s of preload +
+        ffmpeg start-up + player-buffer fill before audio became audible
+        again.
+
+        Therefore we no longer:
+        - set ``_stream_stop_event`` (would force-exit the generator),
+        - call ``mass.players.cmd_stop(player_id)`` (would drain the player).
+
+        ``_stream_stop_event`` stays the sole responsibility of "permanent"
+        teardown paths (``_clear_active_player``, ``unload``). The generator
+        notices ``self._ynison.state.is_paused`` directly and re-routes into
+        the silence loop.
+        """
         player_id = self._in_use_by_queue
         if player_id:
-            try:
-                await self.mass.players.cmd_stop(player_id)
-            except Exception:
-                self.logger.debug("Failed to stop player %s on pause", player_id)
             self.mass.players.trigger_player_update(player_id)
 
     # ------------------------------------------------------------------

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -114,6 +114,14 @@ _VALID_BIT_DEPTHS: frozenset[str] = frozenset({"16", "24"})
 class YandexYnisonProvider(PluginProvider):
     """Implementation of the Yandex Music Connect (Ynison) Plugin."""
 
+    # Upstream MA's audio_analysis providers (Loudness Analysis, Smart Fades)
+    # branch on `provider.is_streaming_provider` to decide whether to run an
+    # analysis pass. The `PluginProvider` base class does not declare the
+    # attribute, so without this class-level default the analysers raise
+    # `AttributeError` once per track. We're a live source — analysing each
+    # transient track buys nothing — so opt out explicitly.
+    is_streaming_provider: bool = False
+
     @property
     def instance_name_postfix(self) -> str | None:
         """Return display name as instance postfix for multi-instance setups."""
@@ -352,8 +360,15 @@ class YandexYnisonProvider(PluginProvider):
         """
         self._stream_stop_event.clear()
         # snapshot the consumer at session start; the rest of this generator
-        # treats the queue_id as the player_id (they are the same by convention)
+        # treats the queue_id as the player_id (they are the same by convention).
+        # The lock may legitimately be empty here — MA's `_load_item` preload
+        # path drives the generator to fill an initial audio buffer BEFORE
+        # `on_source_selected` has been dispatched, so `_in_use_by_queue` is
+        # still None on that call. `had_claim` records whether a lock was
+        # already in force at entry; only in that case do we enforce
+        # cross-session invariants on the loop and the `finally` cleanup.
         player_id = self._in_use_by_queue or ""
+        had_claim = self._in_use_by_queue is not None
         # Snapshot the active session id too so a same-queue reconnect (which
         # updates _active_session_id but not _in_use_by_queue) is treated as a
         # superseding session: the loop exits early, and the finally clear
@@ -375,10 +390,15 @@ class YandexYnisonProvider(PluginProvider):
         session_fmt: AudioFormat = make_pcm_format(session_params)
 
         try:
-            while (
-                not self._stream_stop_event.is_set()
-                and self._in_use_by_queue == player_id
-                and self._active_session_id == captured_session_id
+            while not self._stream_stop_event.is_set() and (
+                # Preload path: no claim was active at entry — drive the loop
+                # purely off Ynison state and the stop event. on_source_selected
+                # may fire later; it doesn't disqualify us mid-stream.
+                not had_claim
+                or (
+                    self._in_use_by_queue == player_id
+                    and self._active_session_id == captured_session_id
+                )
             ):
                 if not self._ynison or not self._ynison.state.current_track_id:
                     # Wait for a track to appear
@@ -402,8 +422,13 @@ class YandexYnisonProvider(PluginProvider):
                     pause_deadline = time.monotonic() + 30.0
                     while (
                         not self._stream_stop_event.is_set()
-                        and self._in_use_by_queue == player_id
-                        and self._active_session_id == captured_session_id
+                        and (
+                            not had_claim
+                            or (
+                                self._in_use_by_queue == player_id
+                                and self._active_session_id == captured_session_id
+                            )
+                        )
                         and self._ynison
                         and self._ynison.state.current_track_id == track_id
                         and self._ynison.state.is_paused
@@ -447,8 +472,13 @@ class YandexYnisonProvider(PluginProvider):
                     if (
                         self._track_changed_event.is_set()
                         or self._stream_stop_event.is_set()
-                        or self._in_use_by_queue != player_id
-                        or self._active_session_id != captured_session_id
+                        or (
+                            had_claim
+                            and (
+                                self._in_use_by_queue != player_id
+                                or self._active_session_id != captured_session_id
+                            )
+                        )
                     ):
                         break
 
@@ -481,13 +511,16 @@ class YandexYnisonProvider(PluginProvider):
                 # the top of the loop from the latest Ynison state.
                 self._current_streaming_track_id = None
         finally:
-            # Release ownership only if no one else has claimed the source since
-            # this session started. Guard on BOTH the queue id AND the session
-            # id — a same-queue reconnect refreshes the session id without
-            # changing the queue id, and clearing the lock on the old
-            # generator's teardown would clobber the new session's claim.
+            # Release ownership only if THIS generator owned the claim at
+            # entry AND no one else has superseded it since. The double-guard
+            # protects against a same-queue reconnect refreshing the session
+            # id without changing the queue id; clearing the lock on the old
+            # generator's teardown would otherwise clobber the new session's
+            # claim. `had_claim` keeps the preload path from touching the lock
+            # at all (no claim ever existed to release).
             if (
-                self._in_use_by_queue == player_id
+                had_claim
+                and self._in_use_by_queue == player_id
                 and self._active_session_id == captured_session_id
             ):
                 self._in_use_by_queue = None

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -1115,6 +1115,19 @@ class YandexYnisonProvider(PluginProvider):
         if not target:
             self.logger.info("Pause requested but no active queue (_in_use_by_queue is None)")
             return
+        # Rewrite `_active_player_id` to the queue id BEFORE cmd_stop.
+        # `on_source_selected` had stamped `_active_player_id` with the
+        # player MA hands stream-bytes to (the Sendspin bridge `spb_*`
+        # when Local Audio Out wraps the bare ALSA UUID). MA's
+        # `player_queues.play_media` requires a queue_id, and queues live
+        # on the BARE UUID — they don't exist for `spb_*` wrappers. Once
+        # `on_source_unselected` clears `_in_use_by_queue`, the only
+        # surviving id pointer is `_active_player_id`; if it still points
+        # at the bridge, the resume edge in `_activate_playback` calls
+        # `play_media("spb_*", ...)` and MA raises
+        # `PlayerUnavailableError: Queue spb_... is not available`.
+        # Mirror AriaCast (`ariacast_receiver/__init__.py:485`).
+        self._active_player_id = target
         self.logger.info("Pause: cmd_stop(%s) — release player so MA UI flips to IDLE", target)
         # Exit the audio generator promptly. The while-loop guard at the
         # top of get_audio_stream notices and ends; the finally clause

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Yandex Music Connect (Ynison) provider for Music Assistant"
 requires-python = ">=3.14"
 dynamic = ["version"]
 dependencies = [
-  "ya-passport-auth>=1.3.0",
+  "ya-passport-auth>=1.4.1",
   # Provider imports `music_assistant_models` at runtime; pin the minimum
   # version that ships AudioSource / SourceControl / ResourceBusyError
   # (introduced for MA's AudioSource MediaItem contract).

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -102,6 +102,8 @@ def _make_mock_mass() -> MagicMock:
     mass.players.all_players = MagicMock(return_value=[])
     mass.players.get_player = MagicMock(return_value=None)
     mass.players.cmd_stop = AsyncMock()
+    mass.players.cmd_pause = AsyncMock()
+    mass.players.cmd_play = AsyncMock()
     mass.players.cmd_volume_set = AsyncMock()
     mass.players.trigger_player_update = MagicMock()
 
@@ -1801,6 +1803,16 @@ class TestPausePlayback:
 
         provider.mass.players.cmd_stop.assert_not_called()
 
+    async def test_calls_cmd_pause_to_drive_player_state(self) -> None:
+        """Pause must signal cmd_pause so MA's player state machine flips."""
+        provider = _make_provider()
+        provider._in_use_by_queue = "player1"
+
+        await provider._pause_playback()
+
+        provider.mass.players.cmd_pause.assert_awaited_once_with("player1")
+        assert provider._paused_at_player is True
+
     async def test_preserves_in_use_by_queue(self) -> None:
         """The lock stays with the active session — release is the teardown's job."""
         provider = _make_provider()
@@ -1820,15 +1832,6 @@ class TestPausePlayback:
 
         assert provider._streaming_progress_ms == 50_000
 
-    async def test_triggers_player_update_when_active(self) -> None:
-        """When a player is bound, surface the pause to MA's UI."""
-        provider = _make_provider()
-        provider._in_use_by_queue = "player1"
-
-        await provider._pause_playback()
-
-        provider.mass.players.trigger_player_update.assert_called_with("player1")
-
     async def test_no_active_player_is_a_noop(self) -> None:
         """Pause with no active player neither hard-stops nor errors."""
         provider = _make_provider()
@@ -1838,7 +1841,8 @@ class TestPausePlayback:
 
         assert not provider._stream_stop_event.is_set()
         provider.mass.players.cmd_stop.assert_not_called()
-        provider.mass.players.trigger_player_update.assert_not_called()
+        provider.mass.players.cmd_pause.assert_not_called()
+        assert provider._paused_at_player is False
 
 
 # ------------------------------------------------------------------
@@ -2208,6 +2212,60 @@ class TestActivatePlayback:
 
         assert provider._active_player_id == "player1"
         provider.mass.create_task.assert_called()  # type: ignore[unreachable]
+
+    async def test_unpause_edge_calls_cmd_play(self) -> None:
+        """Entering _activate_playback while `_paused_at_player` issues cmd_play."""
+        provider = _make_provider()
+        provider._paused_at_player = True
+        provider._active_player_id = "player1"
+
+        player = MagicMock()
+        player.player_id = "player1"
+        provider.mass.players.all_players.return_value = [player]
+        provider.mass.players.get_player.return_value = player
+
+        state = _make_ynison_state(progress_ms=0, paused=False)
+
+        await provider._activate_playback(state)
+
+        provider.mass.players.cmd_play.assert_awaited_once_with("player1")
+        assert provider._paused_at_player is False
+
+    async def test_unpause_edge_clears_flag_even_on_cmd_play_failure(self) -> None:
+        """A cmd_play exception must not strand `_paused_at_player`."""
+        provider = _make_provider()
+        provider._paused_at_player = True
+        provider._active_player_id = "player1"
+
+        player = MagicMock()
+        player.player_id = "player1"
+        provider.mass.players.all_players.return_value = [player]
+        provider.mass.players.get_player.return_value = player
+        provider.mass.players.cmd_play = AsyncMock(side_effect=RuntimeError("boom"))
+
+        state = _make_ynison_state(progress_ms=0, paused=False)
+
+        # Must not raise — failure swallowed; flag still cleared.
+        await provider._activate_playback(state)
+
+        assert provider._paused_at_player is False
+
+    async def test_active_playback_no_pause_flag_does_not_call_cmd_play(self) -> None:
+        """When we never paused at the player, cmd_play must not fire."""
+        provider = _make_provider()
+        provider._paused_at_player = False
+        provider._active_player_id = "player1"
+
+        player = MagicMock()
+        player.player_id = "player1"
+        provider.mass.players.all_players.return_value = [player]
+        provider.mass.players.get_player.return_value = player
+
+        state = _make_ynison_state(progress_ms=0, paused=False)
+
+        await provider._activate_playback(state)
+
+        provider.mass.players.cmd_play.assert_not_called()
 
     async def test_detects_track_change(self) -> None:
         """Detects track change and updates streaming track id."""

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -16,7 +16,7 @@ from music_assistant_models.enums import (
     ProviderType,
 )
 from music_assistant_models.errors import LoginFailed, UnsupportedFeaturedException
-from music_assistant_models.media_items import AudioSource
+from music_assistant_models.media_items import AudioFormat, AudioSource
 from ya_passport_auth import SecretStr
 
 from music_assistant.helpers.throttle_retry import BYPASS_THROTTLER
@@ -2667,6 +2667,85 @@ class TestPrefetchOrdering:
         assert order, "expected at least a prefetch call"
         assert order[0].startswith("prefetch:track42")
         assert any(c.startswith("play_media:player1") for c in order[1:])
+
+
+class TestPrefetchFlowsThroughToStreamDetails:
+    """`get_stream_details` returns the *prefetched* AudioFormat.
+
+    Pins the contract that MA's upstream passthrough path (#3969,
+    `_select_audio_source_pcm_format`) honors: MA reads
+    ``streamdetails.audio_format`` and only invokes ffmpeg when it
+    cannot match the player's supported rates. A regression that
+    decouples ``_prefetch_format_for_track`` from
+    ``self._normalized_params`` (or that returns a stale snapshot in
+    ``get_stream_details``) would silently downgrade hi-res passthrough
+    to a forced ffmpeg resample with no functional indicator beyond
+    log entropy.
+    """
+
+    async def test_prefetch_updates_streamdetails_audio_format(self) -> None:
+        """Prefetched source rate/bit-depth must reach `get_stream_details`."""
+        from music_assistant_models.enums import MediaType  # noqa: PLC0415
+
+        provider = _make_provider()
+        # Default before prefetch: lossy PCM (16-bit / 44.1 kHz auto base).
+        default_rate = provider._normalized_params["sample_rate"]
+        default_depth = provider._normalized_params["bit_depth"]
+        assert default_rate != 96_000  # sanity: ensure we'll see a change
+
+        mock_yandex = MagicMock()
+
+        async def _fake_get_stream_details(_track_id: str, _media_type: MediaType) -> Any:
+            sd = MagicMock()
+            sd.expiration = 60
+            sd.duration = 200
+            sd.data = None
+            sd.audio_format = AudioFormat(
+                content_type=ContentType.FLAC,
+                sample_rate=96_000,
+                bit_depth=24,
+                channels=2,
+            )
+            sd.to_dict = MagicMock(return_value={})
+            return sd
+
+        mock_yandex.get_stream_details = AsyncMock(side_effect=_fake_get_stream_details)
+        provider._yandex_provider = mock_yandex
+        # Set explicit AUTO so prefetch hint is allowed to promote both axes.
+        provider._cfg_sample_rate = OUTPUT_AUTO
+        provider._cfg_bit_depth = OUTPUT_AUTO
+
+        await provider._prefetch_format_for_track("track42")
+
+        # `_normalized_params` lifted to source rate/bit-depth.
+        assert provider._normalized_params["sample_rate"] == 96_000
+        assert provider._normalized_params["bit_depth"] == 24
+        # And get_stream_details now reflects that — MA's
+        # `_select_audio_source_pcm_format` consumes this.
+        sd = await provider.get_stream_details("main", "queue1")
+        assert sd.media_type == MediaType.AUDIO_SOURCE
+        assert sd.audio_format.sample_rate == 96_000
+        assert sd.audio_format.bit_depth == 24
+        assert sd.audio_format.channels == 2
+
+    async def test_streamdetails_audio_format_is_fresh_copy_per_call(self) -> None:
+        """Each `get_stream_details` returns a fresh AudioFormat instance.
+
+        `AudioFormat` is mutable (MA's outer ffmpeg sets `codec_type` in
+        place). A shared instance across `get_stream_details` calls
+        would let one consumer's mutation poison the next one's
+        snapshot — which #3969's passthrough specifically depends on
+        for the format-match comparison.
+        """
+        from music_assistant_models.enums import MediaType  # noqa: PLC0415
+
+        provider = _make_provider()
+        sd1 = await provider.get_stream_details("main", "queue1")
+        sd2 = await provider.get_stream_details("main", "queue1")
+
+        assert sd1.media_type == MediaType.AUDIO_SOURCE
+        assert sd1.audio_format == sd2.audio_format  # value-equal
+        assert sd1.audio_format is not sd2.audio_format  # not the same instance
 
 
 class TestAudioStreamPausedReturn:

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -107,8 +107,11 @@ def _make_mock_mass() -> MagicMock:
     mass.players.cmd_volume_set = AsyncMock()
     mass.players.trigger_player_update = MagicMock()
 
-    # Player queues — external triggers route through player_queues.play_media now
+    # Player queues — external triggers route through player_queues.play_media,
+    # pause/play go through queue-level commands (Ynison-driven pause flow).
     mass.player_queues.play_media = AsyncMock()
+    mass.player_queues.pause = AsyncMock()
+    mass.player_queues.play = AsyncMock()
 
     # Streams — live metadata updates flow through update_stream_metadata
     mass.streams.update_stream_metadata = MagicMock()
@@ -1809,21 +1812,23 @@ class TestPausePlayback:
 
         provider.mass.players.cmd_stop.assert_not_called()
 
-    async def test_calls_cmd_pause_with_active_player_id_not_queue_id(self) -> None:
-        """cmd_pause must target the bridge player (`_active_player_id`),
-        not the bare queue UUID. The bridge owns the stream and MA's UI
-        consults its state machine.
+    async def test_calls_queue_pause_with_queue_id(self) -> None:
+        """Pause must target the queue (`player_queues.pause(queue_id)`),
+        not the player. The queue owns the playback_state that MA's UI
+        reads — pausing the underlying player without flipping the queue
+        leaves the UI stuck in "playing".
         """
         provider = _make_provider()
         # Bridge wraps the bare ALSA player UUID; on_source_selected sets
         # `_active_player_id` to the bridge and `_in_use_by_queue` to the
-        # queue's underlying bare UUID — they differ when a bridge exists.
+        # queue id (bare UUID). The queue is what we drive.
         provider._active_player_id = "spb_bridge1"
         provider._in_use_by_queue = "player1"
 
         await provider._pause_playback()
 
-        provider.mass.players.cmd_pause.assert_awaited_once_with("spb_bridge1")
+        provider.mass.player_queues.pause.assert_awaited_once_with("player1")
+        provider.mass.players.cmd_pause.assert_not_called()
         assert provider._paused_at_player is True
 
     async def test_preserves_in_use_by_queue(self) -> None:
@@ -2229,14 +2234,18 @@ class TestActivatePlayback:
         assert provider._active_player_id == "player1"
         provider.mass.create_task.assert_called()  # type: ignore[unreachable]
 
-    async def test_unpause_edge_calls_cmd_play(self) -> None:
-        """Entering _activate_playback while `_paused_at_player` issues cmd_play."""
+    async def test_unpause_edge_calls_queue_play_with_queue_id(self) -> None:
+        """Entering _activate_playback while `_paused_at_player` issues
+        `player_queues.play(queue_id)` so the queue's playback_state flips
+        back to PLAYING.
+        """
         provider = _make_provider()
         provider._paused_at_player = True
-        provider._active_player_id = "player1"
+        provider._active_player_id = "spb_bridge1"
+        provider._in_use_by_queue = "player1"  # queue id
 
         player = MagicMock()
-        player.player_id = "player1"
+        player.player_id = "spb_bridge1"
         provider.mass.players.all_players.return_value = [player]
         provider.mass.players.get_player.return_value = player
 
@@ -2244,20 +2253,22 @@ class TestActivatePlayback:
 
         await provider._activate_playback(state)
 
-        provider.mass.players.cmd_play.assert_awaited_once_with("player1")
+        provider.mass.player_queues.play.assert_awaited_once_with("player1")
+        provider.mass.players.cmd_play.assert_not_called()
         assert provider._paused_at_player is False
 
-    async def test_unpause_edge_clears_flag_even_on_cmd_play_failure(self) -> None:
-        """A cmd_play exception must not strand `_paused_at_player`."""
+    async def test_unpause_edge_clears_flag_even_on_queue_play_failure(self) -> None:
+        """A queue.play exception must not strand `_paused_at_player`."""
         provider = _make_provider()
         provider._paused_at_player = True
-        provider._active_player_id = "player1"
+        provider._active_player_id = "spb_bridge1"
+        provider._in_use_by_queue = "player1"
 
         player = MagicMock()
-        player.player_id = "player1"
+        player.player_id = "spb_bridge1"
         provider.mass.players.all_players.return_value = [player]
         provider.mass.players.get_player.return_value = player
-        provider.mass.players.cmd_play = AsyncMock(side_effect=RuntimeError("boom"))
+        provider.mass.player_queues.play = AsyncMock(side_effect=RuntimeError("boom"))
 
         state = _make_ynison_state(progress_ms=0, paused=False)
 
@@ -2266,14 +2277,15 @@ class TestActivatePlayback:
 
         assert provider._paused_at_player is False
 
-    async def test_active_playback_no_pause_flag_does_not_call_cmd_play(self) -> None:
-        """When we never paused at the player, cmd_play must not fire."""
+    async def test_active_playback_no_pause_flag_does_not_call_queue_play(self) -> None:
+        """When we never paused, queue.play must not fire on activation."""
         provider = _make_provider()
         provider._paused_at_player = False
-        provider._active_player_id = "player1"
+        provider._active_player_id = "spb_bridge1"
+        provider._in_use_by_queue = "player1"
 
         player = MagicMock()
-        player.player_id = "player1"
+        player.player_id = "spb_bridge1"
         provider.mass.players.all_players.return_value = [player]
         provider.mass.players.get_player.return_value = player
 
@@ -2281,7 +2293,7 @@ class TestActivatePlayback:
 
         await provider._activate_playback(state)
 
-        provider.mass.players.cmd_play.assert_not_called()
+        provider.mass.player_queues.play.assert_not_called()
 
     async def test_detects_track_change(self) -> None:
         """Detects track change and updates streaming track id."""

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1808,15 +1808,26 @@ class TestPausePlayback:
         assert provider._stream_stop_event.is_set()
         provider.mass.players.cmd_stop.assert_awaited_once_with("player1")
 
-    async def test_preserves_active_player_id_for_resume(self) -> None:
-        """`_active_player_id` survives pause so resume can reclaim the same player."""
+    async def test_rewrites_active_player_id_to_queue_id_before_stop(self) -> None:
+        """Pause must rewrite `_active_player_id` to the queue id (bare UUID).
+
+        on_source_selected stamps `_active_player_id` with the player MA
+        actually streams to — for Local Audio Out + Sendspin that is the
+        bridge wrapper (`spb_*`). MA's `player_queues.play_media`
+        requires a queue_id, and queues live on the bare UUID, not on
+        the bridge. If `_active_player_id` stays pointing at the bridge
+        after on_source_unselected clears `_in_use_by_queue`, the resume
+        edge in `_activate_playback` calls `play_media("spb_*", ...)`
+        which raises PlayerUnavailableError. Mirror AriaCast's fix
+        (`ariacast_receiver/__init__.py:485`).
+        """
         provider = _make_provider()
-        provider._active_player_id = "spb_bridge1"
-        provider._in_use_by_queue = "player1"
+        provider._active_player_id = "spb_bridge1"  # bridge from on_source_selected
+        provider._in_use_by_queue = "player1"  # queue id (bare UUID)
 
         await provider._pause_playback()
 
-        assert provider._active_player_id == "spb_bridge1"
+        assert provider._active_player_id == "player1"
 
     async def test_no_active_player_is_a_noop(self) -> None:
         """Pause with no active queue does not call cmd_stop or set the stop event."""

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1780,35 +1781,64 @@ class TestSendProgressToYnison:
 
 
 class TestPausePlayback:
-    """Tests for _pause_playback."""
+    """Tests for _pause_playback under the silence-keepalive contract."""
 
-    async def test_stops_stream_and_player(self) -> None:
-        """Pause stops stream, calls cmd_stop, preserves progress."""
+    async def test_does_not_set_stop_event(self) -> None:
+        """Pause must keep the generator alive so it can yield silence."""
         provider = _make_provider()
-        provider._streaming_progress_ms = 50000
         provider._in_use_by_queue = "player1"
 
         await provider._pause_playback()
 
-        assert provider._stream_stop_event.is_set()
-        provider.mass.players.cmd_stop.assert_awaited_once_with("player1")  # type: ignore[attr-defined]
-        # _pause_playback no longer pre-clears _in_use_by_queue — the lock
-        # release is owned by serve_queue_item_stream's finally calling
-        # on_source_unselected after cmd_stop's stream drain completes.
-        # Clearing here would double-write against the session-id guard.
-        assert provider._in_use_by_queue == "player1"
-        # Progress is preserved for resume
-        assert provider._streaming_progress_ms == 50000
+        assert not provider._stream_stop_event.is_set()
 
-    async def test_no_active_player(self) -> None:
-        """Pause with no active player just sets stop event."""
+    async def test_does_not_cmd_stop_the_player(self) -> None:
+        """Pause must not hard-stop the player; the silence loop keeps it live."""
+        provider = _make_provider()
+        provider._in_use_by_queue = "player1"
+
+        await provider._pause_playback()
+
+        provider.mass.players.cmd_stop.assert_not_called()
+
+    async def test_preserves_in_use_by_queue(self) -> None:
+        """The lock stays with the active session — release is the teardown's job."""
+        provider = _make_provider()
+        provider._in_use_by_queue = "player1"
+
+        await provider._pause_playback()
+
+        assert provider._in_use_by_queue == "player1"
+
+    async def test_preserves_progress(self) -> None:
+        """Pause must not reset the streaming progress mirror."""
+        provider = _make_provider()
+        provider._streaming_progress_ms = 50_000
+        provider._in_use_by_queue = "player1"
+
+        await provider._pause_playback()
+
+        assert provider._streaming_progress_ms == 50_000
+
+    async def test_triggers_player_update_when_active(self) -> None:
+        """When a player is bound, surface the pause to MA's UI."""
+        provider = _make_provider()
+        provider._in_use_by_queue = "player1"
+
+        await provider._pause_playback()
+
+        provider.mass.players.trigger_player_update.assert_called_with("player1")
+
+    async def test_no_active_player_is_a_noop(self) -> None:
+        """Pause with no active player neither hard-stops nor errors."""
         provider = _make_provider()
         provider._in_use_by_queue = None
 
         await provider._pause_playback()
 
-        assert provider._stream_stop_event.is_set()
-        provider.mass.players.cmd_stop.assert_not_called()  # type: ignore[attr-defined]
+        assert not provider._stream_stop_event.is_set()
+        provider.mass.players.cmd_stop.assert_not_called()
+        provider.mass.players.trigger_player_update.assert_not_called()
 
 
 # ------------------------------------------------------------------
@@ -2534,3 +2564,167 @@ class TestPrefetchOrdering:
         assert order, "expected at least a prefetch call"
         assert order[0].startswith("prefetch:track42")
         assert any(c.startswith("play_media:player1") for c in order[1:])
+
+
+def _make_paused_state(track_id: str = "track42", progress_ms: int = 0) -> YnisonState:
+    """Build a YnisonState marked as paused on `track_id` at `progress_ms`."""
+    state = YnisonState()
+    state.active_device_id = "dev1"
+    state.player_state = {
+        "player_queue": {
+            "playable_list": [{"playable_id": track_id}],
+            "current_playable_index": 0,
+        },
+        "status": {"paused": True, "progress_ms": progress_ms, "duration_ms": 60_000},
+    }
+    return state
+
+
+class TestPauseSilenceKeepalive:
+    """`get_audio_stream` yields PCM silence during pause instead of exiting."""
+
+    async def test_mid_stream_pause_breaks_inner_loop(self) -> None:
+        """A pause arriving mid-track must reroute the generator into silence."""
+        # We exercise the chunk-loop break condition directly: with a paused
+        # Ynison state, the predicate that controls whether to leave
+        # `async for chunk in _stream_track(...)` must evaluate True.
+        provider = _make_provider()
+        ynison = MagicMock()
+        ynison.state.is_paused = True
+        provider._ynison = ynison
+
+        should_break = provider._ynison is not None and provider._ynison.state.is_paused
+        assert should_break
+
+        ynison.state.is_paused = False
+        should_break = provider._ynison is not None and provider._ynison.state.is_paused
+        assert not should_break
+
+    async def test_silence_loop_yields_frame_aligned_zero_pcm(self) -> None:
+        """Driving the generator into the silence branch yields PCM zeros."""
+        provider = _make_provider()
+        # Borrow-mode setup so the generator does not early-return on
+        # _yandex_provider being None.
+        provider._yandex_provider = MagicMock()
+        provider._in_use_by_queue = "queue1"
+        provider._active_session_id = "session-1"
+
+        ynison = MagicMock()
+        ynison.state.is_paused = True
+        ynison.state.current_track_id = "track42"
+        provider._ynison = ynison
+
+        streamdetails = MagicMock()
+        gen = provider.get_audio_stream(streamdetails, seek_position=0)
+
+        async def _flip_to_unpause() -> None:
+            # Give the generator one tick to enter the silence loop, then
+            # also flip is_paused so the loop exits on the next iteration.
+            await asyncio.sleep(0.05)
+            ynison.state.is_paused = False
+            # Setting the event wakes the generator immediately.
+            provider._track_changed_event.set()
+
+        flipper = asyncio.create_task(_flip_to_unpause())
+        chunk = await asyncio.wait_for(gen.__anext__(), timeout=2.0)
+        await flipper
+        # Stop the generator cleanly so the test does not hang.
+        provider._stream_stop_event.set()
+        with suppress(StopAsyncIteration, asyncio.CancelledError):
+            await gen.aclose()
+
+        # Silence is PCM zeros of frame-aligned length.
+        assert chunk
+        assert chunk == b"\x00" * len(chunk)
+        # 100 ms @ 48 kHz / 24-bit / 2ch = 4800 samples × 6 bytes = 28800 bytes
+        # (assumes the default lossless PCM profile; if the hint promoted it,
+        # the chunk would still be a multiple of frame_size).
+        # bytes_per_frame for s24le stereo = 6; for s16le stereo = 4.
+        from provider.streaming import (  # noqa: PLC0415 — local import
+            PCM_LOSSLESS_PARAMS,
+            PCM_LOSSY_PARAMS,
+        )
+
+        expected_frame = max(
+            (PCM_LOSSLESS_PARAMS["bit_depth"] // 8) * PCM_LOSSLESS_PARAMS["channels"],
+            (PCM_LOSSY_PARAMS["bit_depth"] // 8) * PCM_LOSSY_PARAMS["channels"],
+        )
+        assert len(chunk) % expected_frame == 0
+
+    async def test_unpause_seeds_seek_position_from_ynison(self) -> None:
+        """Unpause on the same track must seed `_seek_position_ms` from Ynison."""
+        provider = _make_provider()
+        provider._yandex_provider = MagicMock()
+        provider._in_use_by_queue = "queue1"
+        provider._active_session_id = "session-1"
+
+        ynison = MagicMock()
+        ynison.state.is_paused = True
+        ynison.state.current_track_id = "track42"
+        ynison.state.progress_ms = 42_000
+        provider._ynison = ynison
+
+        # _stream_track captures the seek_ms it receives and then exits so
+        # the outer loop terminates cleanly. The streaming branch sets
+        # `_seek_position_ms = 0` right after reading it, so this is the only
+        # observation point.
+        captured_seek_ms: list[int] = []
+
+        async def _stub_stream_track(
+            _track_id: str, *, seek_ms: int = 0, session_params: dict[str, Any] | None = None
+        ) -> Any:
+            captured_seek_ms.append(seek_ms)
+            provider._stream_stop_event.set()
+            if False:
+                yield b""
+
+        _stub_attr(provider, "_stream_track", _stub_stream_track)
+
+        streamdetails = MagicMock()
+        gen = provider.get_audio_stream(streamdetails, seek_position=0)
+
+        async def _flip_to_unpause() -> None:
+            await asyncio.sleep(0.05)
+            ynison.state.is_paused = False
+            provider._track_changed_event.set()
+
+        flipper = asyncio.create_task(_flip_to_unpause())
+        # Consume silence chunks until the generator falls through the pause
+        # branch and hits the (stubbed) streaming branch which stops it.
+        with suppress(StopAsyncIteration):
+            async for _ in gen:
+                pass
+        await flipper
+        await gen.aclose()
+
+        assert captured_seek_ms == [42_000]
+
+    async def test_long_pause_does_not_exit_generator(self) -> None:
+        """A multi-minute pause keeps the silence loop alive (no deadline)."""
+        provider = _make_provider()
+        provider._yandex_provider = MagicMock()
+        provider._in_use_by_queue = "queue1"
+        provider._active_session_id = "session-1"
+
+        ynison = MagicMock()
+        ynison.state.is_paused = True
+        ynison.state.current_track_id = "track42"
+        provider._ynison = ynison
+
+        streamdetails = MagicMock()
+        gen = provider.get_audio_stream(streamdetails, seek_position=0)
+
+        # Pull a handful of silence chunks across a simulated long span;
+        # the generator must keep yielding without auto-exit.
+        chunks: list[bytes] = []
+        for _ in range(5):
+            chunk = await asyncio.wait_for(gen.__anext__(), timeout=1.0)
+            chunks.append(chunk)
+
+        assert len(chunks) == 5
+        assert all(c == b"\x00" * len(c) for c in chunks)
+
+        # Cleanup: signal stop and close.
+        provider._stream_stop_event.set()
+        with suppress(StopAsyncIteration, asyncio.CancelledError):
+            await gen.aclose()

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -19,6 +19,7 @@ from music_assistant_models.errors import LoginFailed, UnsupportedFeaturedExcept
 from music_assistant_models.media_items import AudioSource
 from ya_passport_auth import SecretStr
 
+from music_assistant.helpers.throttle_retry import BYPASS_THROTTLER
 from provider.config_helpers import list_yandex_music_instances
 from provider.constants import (
     CONF_ALLOW_PLAYER_SWITCH,
@@ -47,12 +48,27 @@ from provider.streaming import (
 from provider.ynison_client import YnisonState
 
 
-def _stub_attr(obj: object, name: str, value: Any) -> None:
-    """Assign ``value`` to ``obj.name`` bypassing mypy method-assign and ruff B010.
+def _arm_play_media_recorder(provider: YandexYnisonProvider) -> list[tuple[str, str]]:
+    """Replace `play_media` with a recorder and run `create_task` coros inline.
 
-    Used in tests to replace a real instance method on a strictly typed object
-    (e.g. ``provider.mass.get_provider``) with a MagicMock.
+    Returns the list of (target_id, uri) tuples captured during the test.
+    The inline create_task lets the scheduled `play_media` coroutine
+    actually execute against the recorder.
     """
+    calls: list[tuple[str, str]] = []
+
+    async def _record(target_id: str, uri: str) -> None:
+        calls.append((target_id, uri))
+
+    provider.mass.player_queues.play_media = _record
+    provider.mass.create_task = MagicMock(
+        side_effect=lambda coro, *_a, **_kw: asyncio.get_event_loop().create_task(coro)
+    )
+    return calls
+
+
+def _stub_attr(obj: object, name: str, value: Any) -> None:
+    """Setattr that bypasses mypy method-assign and ruff B010."""
     setattr(obj, name, value)
 
 
@@ -2260,43 +2276,26 @@ class TestActivatePlayback:
         provider.mass.players.all_players.return_value = [player]
         provider.mass.players.get_player.return_value = player
 
-        # Replace play_media with a recorder, and make create_task actually
-        # run the coro inline so the call is observable on the recorder.
-        play_media_calls: list[tuple[str, str]] = []
-
-        async def _record_play_media(target_id: str, uri: str) -> None:
-            play_media_calls.append((target_id, uri))
-
-        provider.mass.player_queues.play_media = _record_play_media
-        provider.mass.create_task = MagicMock(
-            side_effect=lambda coro, *_a, **_kw: asyncio.get_event_loop().create_task(coro)
-        )
+        play_media_calls = _arm_play_media_recorder(provider)
 
         state = _make_ynison_state(progress_ms=10_000, paused=False)
 
         await provider._activate_playback(state)
         await asyncio.sleep(0)  # let the scheduled play_media coro run
 
-        assert len(play_media_calls) == 1, (
-            f"expected exactly one play_media, got {play_media_calls}"
-        )
+        assert len(play_media_calls) == 1
         target_id, uri = play_media_calls[0]
-        # The target must be the (queue id) bare player, NOT the bridge.
-        # The bridge id would point at no queue and raise PlayerUnavailableError.
+        # Target must be the (queue id) bare player, NOT the bridge.
+        # Bridge id has no queue → PlayerUnavailableError.
         assert target_id == "player1"
         assert uri == str(provider._audio_source.uri)
         assert not provider._stream_stop_event.is_set()
 
     async def test_resume_via_paused_flag_alone(self) -> None:
-        """Resume must fire play_media even if stream_stop_event was cleared.
-
-        Pins the explicit `_paused` flag as a second resume signal —
-        guards against a stray code path clearing the stop event
-        between `_pause_playback` and `_activate_playback`.
-        """
+        """Resume fires play_media even if `_stream_stop_event` was cleared."""
         provider = _make_provider()
-        provider._stream_stop_event.clear()  # event NOT set
-        provider._paused = True  # only the explicit flag
+        provider._stream_stop_event.clear()
+        provider._paused = True
         provider._active_player_id = "player1"
         provider._in_use_by_queue = None
 
@@ -2305,15 +2304,7 @@ class TestActivatePlayback:
         provider.mass.players.all_players.return_value = [player]
         provider.mass.players.get_player.return_value = player
 
-        play_media_calls: list[tuple[str, str]] = []
-
-        async def _record_play_media(target_id: str, uri: str) -> None:
-            play_media_calls.append((target_id, uri))
-
-        provider.mass.player_queues.play_media = _record_play_media
-        provider.mass.create_task = MagicMock(
-            side_effect=lambda coro, *_a, **_kw: asyncio.get_event_loop().create_task(coro)
-        )
+        play_media_calls = _arm_play_media_recorder(provider)
 
         await provider._activate_playback(_make_ynison_state(progress_ms=10_000, paused=False))
         await asyncio.sleep(0)
@@ -2682,14 +2673,7 @@ class TestAudioStreamPausedReturn:
     """`get_audio_stream` exits immediately when Ynison reports paused."""
 
     async def test_paused_state_exits_generator_without_yielding(self) -> None:
-        """A paused-at-entry session yields zero chunks and the generator ends.
-
-        This pins the AriaCast-pattern invariant: pause is handled by
-        `_pause_playback` (cmd_stop + stream_stop_event); the audio
-        generator's own contract on `is_paused` is to bail. Any
-        regression that reintroduces a silence loop or a wait for
-        unpause would fail this test.
-        """
+        """A paused-at-entry session yields zero chunks and the generator ends."""
         provider = _make_provider()
         provider._yandex_provider = MagicMock()
         provider._in_use_by_queue = "player1"
@@ -2712,67 +2696,16 @@ class TestAudioStreamPausedReturn:
 
 
 class TestNaturalEndDifferentiation:
-    """`_signal_track_completion` fires ONLY on clean iterator exhaustion."""
+    """`_signal_track_completion` fires only on clean iterator exhaustion.
 
-    async def _drive_one_track(
-        self,
-        provider: YandexYnisonProvider,
-        *,
-        set_track_change: bool = False,
-        set_stop: bool = False,
-        set_paused: bool = False,
-        set_session_change: bool = False,
-    ) -> int:
-        """Drive the generator for one chunk and trigger the requested exit.
-
-        Returns the number of times `_signal_track_completion` ran.
-        """
-        signal_calls = 0
-
-        async def _spy_signal() -> None:
-            nonlocal signal_calls
-            signal_calls += 1
-
-        _stub_attr(provider, "_signal_track_completion", _spy_signal)
-
-        # Stub `_wait_for_track_change` so the signal path doesn't block.
-        async def _wait_stub(_old: str, timeout: float = 30.0) -> bool:  # noqa: ARG001
-            return True
-
-        _stub_attr(provider, "_wait_for_track_change", _wait_stub)
-
-        async def _stub_stream_track(
-            _track_id: str, *, seek_ms: int = 0, session_params: dict[str, Any] | None = None
-        ) -> Any:
-            # Mid-chunk: arm the requested exit condition.
-            if set_track_change:
-                provider._track_changed_event.set()
-            if set_stop:
-                provider._stream_stop_event.set()
-            if set_paused:
-                # is_paused on YnisonState is a property derived from
-                # player_state['status']['paused']. Flip via the state dict.
-                assert provider._ynison is not None
-                provider._ynison.state.player_state["status"]["paused"] = True
-            if set_session_change:
-                provider._active_session_id = "different-session"
-            yield b"\x00\x00\x00\x00"
-
-        _stub_attr(provider, "_stream_track", _stub_stream_track)
-
-        # `_wait_for_track_change` returns True so the outer loop will iterate;
-        # break it out after one iteration by setting stop on second pass.
-        # The exit conditions above already cover that.
-        streamdetails = MagicMock()
-        gen = provider.get_audio_stream(streamdetails, seek_position=0)
-        with suppress(StopAsyncIteration):
-            for _ in range(3):  # drain a few iterations max
-                await asyncio.wait_for(gen.__anext__(), timeout=1.0)
-                # Force stop on next outer iteration so the test terminates.
-                provider._stream_stop_event.set()
-        with suppress(StopAsyncIteration, asyncio.CancelledError):
-            await gen.aclose()
-        return signal_calls
+    These tests exercise the post-inner-loop branch via
+    ``_wait_for_track_change`` as the outer-loop gate. The previous
+    iteration set ``_stream_stop_event`` between yields, which made the
+    stop-event guard above ``natural_end`` short-circuit the very logic
+    we wanted to verify — the tests passed for the wrong reason. The
+    rewritten infra lets ``natural_end`` actually evaluate and uses the
+    ``_wait_for_track_change`` stub to terminate the outer loop.
+    """
 
     def _build(self) -> YandexYnisonProvider:
         provider = _make_provider()
@@ -2788,59 +2721,132 @@ class TestNaturalEndDifferentiation:
         provider._ynison = ynison
         return provider
 
-    async def test_track_change_does_not_signal_completion(self) -> None:
-        """`_track_changed_event` set inside chunk loop → no completion signal."""
-        provider = self._build()
-        calls = await self._drive_one_track(provider, set_track_change=True)
-        assert calls == 0
+    @staticmethod
+    def _spy_signal(provider: YandexYnisonProvider) -> list[int]:
+        calls: list[int] = []
 
-    async def test_pause_does_not_signal_completion(self) -> None:
-        """is_paused flipped True inside chunk loop → no completion signal."""
-        provider = self._build()
-        calls = await self._drive_one_track(provider, set_paused=True)
-        assert calls == 0
+        async def _spy() -> None:
+            calls.append(1)
 
-    async def test_session_change_does_not_signal_completion(self) -> None:
-        """`_active_session_id` rotated mid-stream → no completion signal."""
-        provider = self._build()
-        calls = await self._drive_one_track(provider, set_session_change=True)
-        assert calls == 0
+        _stub_attr(provider, "_signal_track_completion", _spy)
+        return calls
 
-    async def test_clean_exhaustion_signals_completion(self) -> None:
-        """`_stream_track` exhausting naturally (no break flags) → completion fires."""
-        provider = self._build()
-        signal_calls = 0
+    @staticmethod
+    def _gate_outer_loop_after_signal(provider: YandexYnisonProvider) -> None:
+        """`_wait_for_track_change` returns False → outer loop exits.
 
-        async def _spy_signal() -> None:
-            nonlocal signal_calls
-            signal_calls += 1
+        ``natural_end`` calls `_wait_for_track_change`; we use its
+        return as the gate so the test terminates AFTER natural_end
+        has had a chance to evaluate. For non-natural-end paths
+        (track-change / session-change), `_wait_for_track_change` is
+        never called — we gate those via `_stream_stop_event.set()`
+        inside the chunk-yield stub, AFTER one full outer iteration.
+        """
 
-        _stub_attr(provider, "_signal_track_completion", _spy_signal)
-
-        async def _wait_stub(_old: str, timeout: float = 30.0) -> bool:  # noqa: ARG001
-            # After signalling, stop the outer loop.
+        async def _wait_false(_old: str, timeout: float = 30.0) -> bool:  # noqa: ARG001
             provider._stream_stop_event.set()
             return False
 
-        _stub_attr(provider, "_wait_for_track_change", _wait_stub)
+        _stub_attr(provider, "_wait_for_track_change", _wait_false)
 
-        async def _natural_end_stream(
+    @staticmethod
+    async def _drive_to_exhaustion(provider: YandexYnisonProvider) -> None:
+        streamdetails = MagicMock()
+        gen = provider.get_audio_stream(streamdetails, seek_position=0)
+        try:
+            with suppress(StopAsyncIteration):
+                async for _ in gen:
+                    pass
+        finally:
+            with suppress(StopAsyncIteration, asyncio.CancelledError):
+                await gen.aclose()
+
+    async def test_clean_exhaustion_signals_completion(self) -> None:
+        """Inner loop exhausts naturally → `_signal_track_completion` fires once."""
+        provider = self._build()
+        calls = self._spy_signal(provider)
+        self._gate_outer_loop_after_signal(provider)
+
+        async def _natural_end(
             _track_id: str, *, seek_ms: int = 0, session_params: dict[str, Any] | None = None
         ) -> Any:
             yield b"\x00\x00\x00\x00"
-            # No break flags set — generator simply exhausts.
+            # generator exhausts cleanly — no break flag set
 
-        _stub_attr(provider, "_stream_track", _natural_end_stream)
+        _stub_attr(provider, "_stream_track", _natural_end)
 
-        streamdetails = MagicMock()
-        gen = provider.get_audio_stream(streamdetails, seek_position=0)
-        with suppress(StopAsyncIteration):
-            async for _ in gen:
-                pass
-        with suppress(StopAsyncIteration, asyncio.CancelledError):
-            await gen.aclose()
+        await self._drive_to_exhaustion(provider)
 
-        assert signal_calls == 1
+        assert calls == [1]
+
+    async def test_track_change_during_chunk_loop_suppresses_signal(self) -> None:
+        """`_track_changed_event` set mid-stream → natural_end False → no signal.
+
+        Uses a two-invocation stub: first call arms `_track_changed_event`
+        (the natural_end check we want to verify), second call sets
+        `_stream_stop_event` to terminate the test. If we set the stop
+        event in the first call, the stop-event guard above natural_end
+        would short-circuit before the differentiation logic runs.
+        """
+        provider = self._build()
+        calls = self._spy_signal(provider)
+
+        invocation_count = 0
+
+        async def _two_pass_stream(
+            _track_id: str, *, seek_ms: int = 0, session_params: dict[str, Any] | None = None
+        ) -> Any:
+            nonlocal invocation_count
+            invocation_count += 1
+            yield b"\x00\x00\x00\x00"
+            if invocation_count == 1:
+                # First pass: arm the break flag. natural_end will see it
+                # and (correctly) suppress the signal. Outer loop re-iterates.
+                provider._track_changed_event.set()
+            else:
+                # Second pass: stop the test.
+                provider._stream_stop_event.set()
+
+        _stub_attr(provider, "_stream_track", _two_pass_stream)
+
+        await self._drive_to_exhaustion(provider)
+
+        assert calls == []
+        assert invocation_count == 2  # natural_end must have evaluated on pass 1
+
+    async def test_session_change_during_chunk_loop_suppresses_signal(self) -> None:
+        """Session-id rotation mid-stream → `broke_for_session_change` → no signal.
+
+        The session-mismatch breaks both the inner chunk loop's break
+        guard AND the outer-loop's session check, so the generator
+        exits after one iteration without further help — `natural_end`
+        runs once with `broke_for_session_change=True` and must not
+        signal.
+        """
+        provider = self._build()
+        calls = self._spy_signal(provider)
+
+        async def _yield_then_rotate_session(
+            _track_id: str, *, seek_ms: int = 0, session_params: dict[str, Any] | None = None
+        ) -> Any:
+            yield b"\x00\x00\x00\x00"
+            provider._active_session_id = "different-session"
+
+        _stub_attr(provider, "_stream_track", _yield_then_rotate_session)
+
+        await self._drive_to_exhaustion(provider)
+
+        assert calls == []
+
+    # NOTE: `broke_for_pause` inside natural_end is defensive: in
+    # practice every external pause routes through `_pause_playback`,
+    # which sets `_stream_stop_event` BEFORE the chunk loop can reach
+    # the natural_end check (the stop-event guard at the top of
+    # `get_audio_stream`'s outer loop short-circuits first). There is
+    # no production code path that lands at natural_end with
+    # `is_paused=True` and `_stream_stop_event=False`, so the clause
+    # cannot be exercised by a black-box test. It survives as
+    # belt-and-braces; intentionally untested.
 
 
 class TestBypassThrottlerScope:
@@ -2848,10 +2854,6 @@ class TestBypassThrottlerScope:
 
     async def test_bypass_active_during_in_flight_stream_fetch(self) -> None:
         """The in-flight stream-details fetch runs with BYPASS_THROTTLER=True."""
-        from music_assistant.helpers.throttle_retry import (  # noqa: PLC0415 — local import
-            BYPASS_THROTTLER,
-        )
-
         provider = _make_provider()
         observed: list[bool] = []
         mock_yandex = MagicMock()
@@ -2881,21 +2883,20 @@ class TestBypassThrottlerScope:
             yield b"pcm"
 
         with patch("provider.provider.get_ffmpeg_stream", side_effect=_fake_ffmpeg):
-            async for _ in provider._stream_track("track1"):
-                break
+            gen = provider._stream_track("track1")
+            try:
+                async for _ in gen:
+                    break
+            finally:
+                await gen.aclose()
 
         assert observed == [True], (
             f"BYPASS_THROTTLER should be True inside _stream_track, got {observed}"
         )
-        # Token reset cleanly back to False at the surrounding context.
         assert BYPASS_THROTTLER.get() is False
 
     async def test_bypass_not_active_during_prefetch(self) -> None:
         """The prefetch path is intentionally NOT bypassed — opportunistic only."""
-        from music_assistant.helpers.throttle_retry import (  # noqa: PLC0415
-            BYPASS_THROTTLER,
-        )
-
         provider = _make_provider()
         observed: list[bool] = []
         mock_yandex = MagicMock()
@@ -2920,10 +2921,6 @@ class TestBypassThrottlerScope:
 
     async def test_bypass_resets_on_exception(self) -> None:
         """A raise inside the bypassed call must still reset the context-var."""
-        from music_assistant.helpers.throttle_retry import (  # noqa: PLC0415
-            BYPASS_THROTTLER,
-        )
-
         provider = _make_provider()
         mock_yandex = MagicMock()
         mock_yandex.get_stream_details = AsyncMock(side_effect=RuntimeError("boom"))
@@ -2934,7 +2931,10 @@ class TestBypassThrottlerScope:
         provider._ynison = mock_ynison
 
         # _stream_track swallows the exception, sets the stop event, returns.
-        async for _ in provider._stream_track("track1"):
-            pass
+        # Patch asyncio.sleep so the inner retry-with-backoff (2s + 4s) does
+        # not block the test in real time.
+        with patch("provider.provider.asyncio.sleep", new=AsyncMock()):
+            async for _ in provider._stream_track("track1"):
+                pass
 
         assert BYPASS_THROTTLER.get() is False

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1835,7 +1835,7 @@ class TestPausePlayback:
         # must still be the bridge id (rewrite is post-success).
         captured: dict[str, str | None] = {}
 
-        async def _capture_stop(player_id: str) -> None:
+        async def _capture_stop(_player_id: str) -> None:
             captured["active_player_id_at_call"] = provider._active_player_id
 
         provider.mass.players.cmd_stop = AsyncMock(side_effect=_capture_stop)
@@ -2690,7 +2690,6 @@ class TestPrefetchFlowsThroughToStreamDetails:
         provider = _make_provider()
         # Default before prefetch: lossy PCM (16-bit / 44.1 kHz auto base).
         default_rate = provider._normalized_params["sample_rate"]
-        default_depth = provider._normalized_params["bit_depth"]
         assert default_rate != 96_000  # sanity: ensure we'll see a change
 
         mock_yandex = MagicMock()
@@ -2849,6 +2848,7 @@ class TestNaturalEndDifferentiation:
         async def _natural_end(
             _track_id: str, *, seek_ms: int = 0, session_params: dict[str, Any] | None = None
         ) -> Any:
+            del seek_ms, session_params  # signature-compat with _stream_track
             yield b"\x00\x00\x00\x00"
             # generator exhausts cleanly — no break flag set
 
@@ -2875,6 +2875,7 @@ class TestNaturalEndDifferentiation:
         async def _two_pass_stream(
             _track_id: str, *, seek_ms: int = 0, session_params: dict[str, Any] | None = None
         ) -> Any:
+            del seek_ms, session_params  # signature-compat with _stream_track
             nonlocal invocation_count
             invocation_count += 1
             yield b"\x00\x00\x00\x00"
@@ -2908,6 +2909,7 @@ class TestNaturalEndDifferentiation:
         async def _yield_then_rotate_session(
             _track_id: str, *, seek_ms: int = 0, session_params: dict[str, Any] | None = None
         ) -> Any:
+            del seek_ms, session_params  # signature-compat with _stream_track
             yield b"\x00\x00\x00\x00"
             provider._active_session_id = "different-session"
 

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -106,8 +107,7 @@ def _make_mock_mass() -> MagicMock:
     mass.players.cmd_volume_set = AsyncMock()
     mass.players.trigger_player_update = MagicMock()
 
-    # Player queues — external triggers route through player_queues.play_media,
-    # pause/play go through queue-level commands (Ynison-driven pause flow).
+    # Player queues
     mass.player_queues.play_media = AsyncMock()
     mass.player_queues.pause = AsyncMock()
     mass.player_queues.play = AsyncMock()
@@ -1789,16 +1789,10 @@ class TestSendProgressToYnison:
 
 
 class TestPausePlayback:
-    """Tests for _pause_playback under the AriaCast cmd_stop contract."""
+    """Tests for `_pause_playback` — external pause releases the player."""
 
     async def test_sets_stop_event_and_cmd_stops_queue(self) -> None:
-        """External pause must release the player via cmd_stop on the queue id.
-
-        Mirrors upstream AriaCast Receiver
-        (`ariacast_receiver/__init__.py:481-490`). The stop event ends
-        the audio generator; cmd_stop flips MA's player/queue state to
-        IDLE so the UI reflects the pause honestly.
-        """
+        """External pause sets the stop event and calls cmd_stop on the queue id."""
         provider = _make_provider()
         provider._active_player_id = "spb_bridge1"
         provider._in_use_by_queue = "player1"
@@ -1808,26 +1802,61 @@ class TestPausePlayback:
         assert provider._stream_stop_event.is_set()
         provider.mass.players.cmd_stop.assert_awaited_once_with("player1")
 
-    async def test_rewrites_active_player_id_to_queue_id_before_stop(self) -> None:
-        """Pause must rewrite `_active_player_id` to the queue id (bare UUID).
+    async def test_rewrites_active_player_id_after_successful_cmd_stop(self) -> None:
+        """On a successful cmd_stop, `_active_player_id` demotes to the queue id.
 
-        on_source_selected stamps `_active_player_id` with the player MA
-        actually streams to — for Local Audio Out + Sendspin that is the
-        bridge wrapper (`spb_*`). MA's `player_queues.play_media`
-        requires a queue_id, and queues live on the bare UUID, not on
-        the bridge. If `_active_player_id` stays pointing at the bridge
-        after on_source_unselected clears `_in_use_by_queue`, the resume
-        edge in `_activate_playback` calls `play_media("spb_*", ...)`
-        which raises PlayerUnavailableError. Mirror AriaCast's fix
-        (`ariacast_receiver/__init__.py:485`).
+        Queues live on the bare ALSA UUID; bridge wrappers (`spb_*`) do
+        not own one. Resume's `play_media(_active_player_id, ...)`
+        must target the queue id — otherwise MA raises
+        `PlayerUnavailableError`. The demotion happens AFTER cmd_stop
+        so a failure path leaves the bridge id intact for next attempt.
         """
         provider = _make_provider()
-        provider._active_player_id = "spb_bridge1"  # bridge from on_source_selected
-        provider._in_use_by_queue = "player1"  # queue id (bare UUID)
+        provider._active_player_id = "spb_bridge1"
+        provider._in_use_by_queue = "player1"
+
+        # capture _active_player_id at the moment cmd_stop is invoked —
+        # must still be the bridge id (rewrite is post-success).
+        captured: dict[str, str | None] = {}
+
+        async def _capture_stop(player_id: str) -> None:
+            captured["active_player_id_at_call"] = provider._active_player_id
+
+        provider.mass.players.cmd_stop = AsyncMock(side_effect=_capture_stop)
 
         await provider._pause_playback()
 
+        assert captured["active_player_id_at_call"] == "spb_bridge1"
         assert provider._active_player_id == "player1"
+        # _paused flag set so the resume edge in _activate_playback can
+        # detect us even if _stream_stop_event has been cleared by some
+        # other code path.
+        assert provider._paused is True
+
+    async def test_cmd_stop_failure_keeps_bridge_id_intact(self) -> None:
+        """A cmd_stop failure must not demote `_active_player_id`.
+
+        If we demoted to the queue id but cmd_stop never reached MA,
+        the next `_activate_playback` would try `play_media(bare_uuid)`
+        without MA ever having released the bridge — wedges the bridge
+        in an inconsistent state. Better to keep the bridge id pinned
+        and let the next pause attempt redo the cycle.
+        """
+        provider = _make_provider()
+        provider._active_player_id = "spb_bridge1"
+        provider._in_use_by_queue = "player1"
+        provider.mass.players.cmd_stop = AsyncMock(side_effect=RuntimeError("boom"))
+
+        await provider._pause_playback()
+
+        assert provider._active_player_id == "spb_bridge1"
+        # Stream stop event still set — generator must exit even if MA
+        # never confirmed; otherwise we'd serve real audio against a
+        # player MA thinks is detached.
+        assert provider._stream_stop_event.is_set()
+        # _paused stays False on the failure path — we're not in a
+        # "successfully paused, expecting resume" state.
+        assert provider._paused is False
 
     async def test_no_active_player_is_a_noop(self) -> None:
         """Pause with no active queue does not call cmd_stop or set the stop event."""
@@ -2210,40 +2239,87 @@ class TestActivatePlayback:
         provider.mass.create_task.assert_called()  # type: ignore[unreachable]
 
     async def test_unpause_after_external_pause_fires_play_media(self) -> None:
-        """Resume after AriaCast-style cmd_stop fires play_media via needs_reselect.
+        """Resume after pause schedules play_media for the (queue-id) player.
 
-        `_pause_playback` sets `_stream_stop_event` and calls `cmd_stop`;
-        the generator exits, `on_source_unselected` clears the lock.
-        When Ynison reports playing again, `_activate_playback` reads
-        `needs_reselect = _stream_stop_event.is_set()` (still True
-        because `_clear_active_player` did NOT run — pause kept the
-        association) and re-issues `play_media`.
+        Simulates the post-`_pause_playback` state: `_stream_stop_event`
+        set, `_active_player_id` already demoted to the queue id (the
+        pause path's post-cmd_stop rewrite), `_in_use_by_queue` cleared
+        by `on_source_unselected`. `_activate_playback` should fire
+        `play_media(queue_id, audio_source.uri)` and clear the stop
+        event so the next session is free to run.
         """
         provider = _make_provider()
-        # Simulate the post-pause state: stream-stop set, _active_player_id
-        # preserved, _in_use_by_queue cleared by on_source_unselected.
+        # Post-pause state: AriaCast path demoted _active_player_id to
+        # the queue id (bare UUID) after cmd_stop succeeded.
         provider._stream_stop_event.set()
-        provider._active_player_id = "spb_bridge1"
+        provider._active_player_id = "player1"
         provider._in_use_by_queue = None
 
         player = MagicMock()
-        player.player_id = "spb_bridge1"
+        player.player_id = "player1"
         provider.mass.players.all_players.return_value = [player]
         provider.mass.players.get_player.return_value = player
+
+        # Replace play_media with a recorder, and make create_task actually
+        # run the coro inline so the call is observable on the recorder.
+        play_media_calls: list[tuple[str, str]] = []
+
+        async def _record_play_media(target_id: str, uri: str) -> None:
+            play_media_calls.append((target_id, uri))
+
+        provider.mass.player_queues.play_media = _record_play_media
+        provider.mass.create_task = MagicMock(
+            side_effect=lambda coro, *_a, **_kw: asyncio.get_event_loop().create_task(coro)
+        )
 
         state = _make_ynison_state(progress_ms=10_000, paused=False)
 
         await provider._activate_playback(state)
+        await asyncio.sleep(0)  # let the scheduled play_media coro run
 
-        # `_activate_playback` schedules `play_media` via `mass.create_task`;
-        # the mass mock's create_task is a MagicMock that does not actually
-        # run the coro. Asserting the scheduling itself is sufficient —
-        # for end-to-end execution see TestPrefetchOrdering which installs
-        # a custom create_task that does run the coro.
-        provider.mass.create_task.assert_called()
-        # Stop event cleared so the next get_audio_stream session runs
-        # normally.
+        assert len(play_media_calls) == 1, (
+            f"expected exactly one play_media, got {play_media_calls}"
+        )
+        target_id, uri = play_media_calls[0]
+        # The target must be the (queue id) bare player, NOT the bridge.
+        # The bridge id would point at no queue and raise PlayerUnavailableError.
+        assert target_id == "player1"
+        assert uri == str(provider._audio_source.uri)
         assert not provider._stream_stop_event.is_set()
+
+    async def test_resume_via_paused_flag_alone(self) -> None:
+        """Resume must fire play_media even if stream_stop_event was cleared.
+
+        Pins the explicit `_paused` flag as a second resume signal —
+        guards against a stray code path clearing the stop event
+        between `_pause_playback` and `_activate_playback`.
+        """
+        provider = _make_provider()
+        provider._stream_stop_event.clear()  # event NOT set
+        provider._paused = True  # only the explicit flag
+        provider._active_player_id = "player1"
+        provider._in_use_by_queue = None
+
+        player = MagicMock()
+        player.player_id = "player1"
+        provider.mass.players.all_players.return_value = [player]
+        provider.mass.players.get_player.return_value = player
+
+        play_media_calls: list[tuple[str, str]] = []
+
+        async def _record_play_media(target_id: str, uri: str) -> None:
+            play_media_calls.append((target_id, uri))
+
+        provider.mass.player_queues.play_media = _record_play_media
+        provider.mass.create_task = MagicMock(
+            side_effect=lambda coro, *_a, **_kw: asyncio.get_event_loop().create_task(coro)
+        )
+
+        await provider._activate_playback(_make_ynison_state(progress_ms=10_000, paused=False))
+        await asyncio.sleep(0)
+
+        assert play_media_calls, "play_media must fire even without stop event"
+        assert provider._paused is False  # cleared by _activate_playback
 
     async def test_detects_track_change(self) -> None:
         """Detects track change and updates streaming track id."""
@@ -2600,3 +2676,265 @@ class TestPrefetchOrdering:
         assert order, "expected at least a prefetch call"
         assert order[0].startswith("prefetch:track42")
         assert any(c.startswith("play_media:player1") for c in order[1:])
+
+
+class TestAudioStreamPausedReturn:
+    """`get_audio_stream` exits immediately when Ynison reports paused."""
+
+    async def test_paused_state_exits_generator_without_yielding(self) -> None:
+        """A paused-at-entry session yields zero chunks and the generator ends.
+
+        This pins the AriaCast-pattern invariant: pause is handled by
+        `_pause_playback` (cmd_stop + stream_stop_event); the audio
+        generator's own contract on `is_paused` is to bail. Any
+        regression that reintroduces a silence loop or a wait for
+        unpause would fail this test.
+        """
+        provider = _make_provider()
+        provider._yandex_provider = MagicMock()
+        provider._in_use_by_queue = "player1"
+        provider._active_session_id = "session-1"
+
+        ynison = MagicMock()
+        ynison.state.is_paused = True
+        ynison.state.current_track_id = "track42"
+        provider._ynison = ynison
+
+        streamdetails = MagicMock()
+        gen = provider.get_audio_stream(streamdetails, seek_position=0)
+
+        chunks: list[bytes] = []
+        with suppress(StopAsyncIteration):
+            async for chunk in gen:
+                chunks.append(chunk)
+
+        assert chunks == []
+
+
+class TestNaturalEndDifferentiation:
+    """`_signal_track_completion` fires ONLY on clean iterator exhaustion."""
+
+    async def _drive_one_track(
+        self,
+        provider: YandexYnisonProvider,
+        *,
+        set_track_change: bool = False,
+        set_stop: bool = False,
+        set_paused: bool = False,
+        set_session_change: bool = False,
+    ) -> int:
+        """Drive the generator for one chunk and trigger the requested exit.
+
+        Returns the number of times `_signal_track_completion` ran.
+        """
+        signal_calls = 0
+
+        async def _spy_signal() -> None:
+            nonlocal signal_calls
+            signal_calls += 1
+
+        _stub_attr(provider, "_signal_track_completion", _spy_signal)
+
+        # Stub `_wait_for_track_change` so the signal path doesn't block.
+        async def _wait_stub(_old: str, timeout: float = 30.0) -> bool:  # noqa: ARG001
+            return True
+
+        _stub_attr(provider, "_wait_for_track_change", _wait_stub)
+
+        async def _stub_stream_track(
+            _track_id: str, *, seek_ms: int = 0, session_params: dict[str, Any] | None = None
+        ) -> Any:
+            # Mid-chunk: arm the requested exit condition.
+            if set_track_change:
+                provider._track_changed_event.set()
+            if set_stop:
+                provider._stream_stop_event.set()
+            if set_paused:
+                # is_paused on YnisonState is a property derived from
+                # player_state['status']['paused']. Flip via the state dict.
+                assert provider._ynison is not None
+                provider._ynison.state.player_state["status"]["paused"] = True
+            if set_session_change:
+                provider._active_session_id = "different-session"
+            yield b"\x00\x00\x00\x00"
+
+        _stub_attr(provider, "_stream_track", _stub_stream_track)
+
+        # `_wait_for_track_change` returns True so the outer loop will iterate;
+        # break it out after one iteration by setting stop on second pass.
+        # The exit conditions above already cover that.
+        streamdetails = MagicMock()
+        gen = provider.get_audio_stream(streamdetails, seek_position=0)
+        with suppress(StopAsyncIteration):
+            for _ in range(3):  # drain a few iterations max
+                await asyncio.wait_for(gen.__anext__(), timeout=1.0)
+                # Force stop on next outer iteration so the test terminates.
+                provider._stream_stop_event.set()
+        with suppress(StopAsyncIteration, asyncio.CancelledError):
+            await gen.aclose()
+        return signal_calls
+
+    def _build(self) -> YandexYnisonProvider:
+        provider = _make_provider()
+        provider._yandex_provider = MagicMock()
+        provider._in_use_by_queue = "player1"
+        provider._active_session_id = "session-1"
+        ynison = MagicMock()
+        ynison.connected = True
+        ynison.state.is_paused = False
+        ynison.state.current_track_id = "track42"
+        ynison.state.player_state = {"status": {"paused": False}}
+        ynison.update_playing_status = AsyncMock()
+        provider._ynison = ynison
+        return provider
+
+    async def test_track_change_does_not_signal_completion(self) -> None:
+        """`_track_changed_event` set inside chunk loop → no completion signal."""
+        provider = self._build()
+        calls = await self._drive_one_track(provider, set_track_change=True)
+        assert calls == 0
+
+    async def test_pause_does_not_signal_completion(self) -> None:
+        """is_paused flipped True inside chunk loop → no completion signal."""
+        provider = self._build()
+        calls = await self._drive_one_track(provider, set_paused=True)
+        assert calls == 0
+
+    async def test_session_change_does_not_signal_completion(self) -> None:
+        """`_active_session_id` rotated mid-stream → no completion signal."""
+        provider = self._build()
+        calls = await self._drive_one_track(provider, set_session_change=True)
+        assert calls == 0
+
+    async def test_clean_exhaustion_signals_completion(self) -> None:
+        """`_stream_track` exhausting naturally (no break flags) → completion fires."""
+        provider = self._build()
+        signal_calls = 0
+
+        async def _spy_signal() -> None:
+            nonlocal signal_calls
+            signal_calls += 1
+
+        _stub_attr(provider, "_signal_track_completion", _spy_signal)
+
+        async def _wait_stub(_old: str, timeout: float = 30.0) -> bool:  # noqa: ARG001
+            # After signalling, stop the outer loop.
+            provider._stream_stop_event.set()
+            return False
+
+        _stub_attr(provider, "_wait_for_track_change", _wait_stub)
+
+        async def _natural_end_stream(
+            _track_id: str, *, seek_ms: int = 0, session_params: dict[str, Any] | None = None
+        ) -> Any:
+            yield b"\x00\x00\x00\x00"
+            # No break flags set — generator simply exhausts.
+
+        _stub_attr(provider, "_stream_track", _natural_end_stream)
+
+        streamdetails = MagicMock()
+        gen = provider.get_audio_stream(streamdetails, seek_position=0)
+        with suppress(StopAsyncIteration):
+            async for _ in gen:
+                pass
+        with suppress(StopAsyncIteration, asyncio.CancelledError):
+            await gen.aclose()
+
+        assert signal_calls == 1
+
+
+class TestBypassThrottlerScope:
+    """`BYPASS_THROTTLER` is set inside `_stream_track`, NOT inside prefetch."""
+
+    async def test_bypass_active_during_in_flight_stream_fetch(self) -> None:
+        """The in-flight stream-details fetch runs with BYPASS_THROTTLER=True."""
+        from music_assistant.helpers.throttle_retry import (  # noqa: PLC0415 — local import
+            BYPASS_THROTTLER,
+        )
+
+        provider = _make_provider()
+        observed: list[bool] = []
+        mock_yandex = MagicMock()
+
+        async def _fake_get_stream_details(_track_id: str, _media_type: Any) -> Any:
+            observed.append(BYPASS_THROTTLER.get())
+            sd = MagicMock()
+            sd.expiration = 0
+            sd.duration = 1
+            sd.audio_format = MagicMock()
+            return sd
+
+        mock_yandex.get_stream_details = AsyncMock(side_effect=_fake_get_stream_details)
+
+        async def _fake_audio(_details: object) -> Any:
+            yield b"x"
+
+        mock_yandex.get_audio_stream = _fake_audio
+        provider._yandex_provider = mock_yandex
+
+        mock_ynison = MagicMock()
+        mock_ynison.update_playing_status = AsyncMock()
+        mock_ynison.state.is_paused = False
+        provider._ynison = mock_ynison
+
+        async def _fake_ffmpeg(**_kwargs: object) -> Any:
+            yield b"pcm"
+
+        with patch("provider.provider.get_ffmpeg_stream", side_effect=_fake_ffmpeg):
+            async for _ in provider._stream_track("track1"):
+                break
+
+        assert observed == [True], (
+            f"BYPASS_THROTTLER should be True inside _stream_track, got {observed}"
+        )
+        # Token reset cleanly back to False at the surrounding context.
+        assert BYPASS_THROTTLER.get() is False
+
+    async def test_bypass_not_active_during_prefetch(self) -> None:
+        """The prefetch path is intentionally NOT bypassed — opportunistic only."""
+        from music_assistant.helpers.throttle_retry import (  # noqa: PLC0415
+            BYPASS_THROTTLER,
+        )
+
+        provider = _make_provider()
+        observed: list[bool] = []
+        mock_yandex = MagicMock()
+
+        async def _fake_get_stream_details(_track_id: str, _media_type: Any) -> Any:
+            observed.append(BYPASS_THROTTLER.get())
+            sd = MagicMock()
+            sd.expiration = 0
+            sd.audio_format = MagicMock()
+            sd.audio_format.sample_rate = 44100
+            sd.audio_format.bit_depth = 16
+            return sd
+
+        mock_yandex.get_stream_details = AsyncMock(side_effect=_fake_get_stream_details)
+        provider._yandex_provider = mock_yandex
+
+        await provider._prefetch_format_for_track("track1")
+
+        assert observed == [False], (
+            f"BYPASS_THROTTLER must NOT be set during prefetch, got {observed}"
+        )
+
+    async def test_bypass_resets_on_exception(self) -> None:
+        """A raise inside the bypassed call must still reset the context-var."""
+        from music_assistant.helpers.throttle_retry import (  # noqa: PLC0415
+            BYPASS_THROTTLER,
+        )
+
+        provider = _make_provider()
+        mock_yandex = MagicMock()
+        mock_yandex.get_stream_details = AsyncMock(side_effect=RuntimeError("boom"))
+        provider._yandex_provider = mock_yandex
+
+        mock_ynison = MagicMock()
+        mock_ynison.state.is_paused = False
+        provider._ynison = mock_ynison
+
+        # _stream_track swallows the exception, sets the stop event, returns.
+        async for _ in provider._stream_track("track1"):
+            pass
+
+        assert BYPASS_THROTTLER.get() is False

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -518,6 +518,10 @@ class TestYnisonStateHandling:
     async def test_duration_updated_from_stream_details(self) -> None:
         """Duration is updated from stream_details and pushed to Ynison."""
         provider = _make_provider()
+        # trigger_player_update needs the actual player id (bridge), not the
+        # queue id — bridge players (`spb_*`) wrap the bare ALSA UUID and the
+        # MA UI's state machine lives on the bridge.
+        provider._active_player_id = "spb_bridge1"
         provider._in_use_by_queue = "player1"
         mock_ynison = MagicMock()
         mock_ynison.update_playing_status = AsyncMock()
@@ -536,7 +540,7 @@ class TestYnisonStateHandling:
         assert meta.elapsed_time == 30  # 30000ms → 30s
         assert provider._actual_duration_ms == 185000
         provider.mass.players.trigger_player_update.assert_called_once_with(  # type: ignore[attr-defined]
-            "player1", force_update=True
+            "spb_bridge1", force_update=True
         )
         # Real duration pushed to Ynison
         mock_ynison.update_playing_status.assert_awaited_once_with(
@@ -1788,6 +1792,7 @@ class TestPausePlayback:
     async def test_does_not_set_stop_event(self) -> None:
         """Pause must keep the generator alive so it can yield silence."""
         provider = _make_provider()
+        provider._active_player_id = "spb_bridge1"
         provider._in_use_by_queue = "player1"
 
         await provider._pause_playback()
@@ -1797,25 +1802,34 @@ class TestPausePlayback:
     async def test_does_not_cmd_stop_the_player(self) -> None:
         """Pause must not hard-stop the player; the silence loop keeps it live."""
         provider = _make_provider()
+        provider._active_player_id = "spb_bridge1"
         provider._in_use_by_queue = "player1"
 
         await provider._pause_playback()
 
         provider.mass.players.cmd_stop.assert_not_called()
 
-    async def test_calls_cmd_pause_to_drive_player_state(self) -> None:
-        """Pause must signal cmd_pause so MA's player state machine flips."""
+    async def test_calls_cmd_pause_with_active_player_id_not_queue_id(self) -> None:
+        """cmd_pause must target the bridge player (`_active_player_id`),
+        not the bare queue UUID. The bridge owns the stream and MA's UI
+        consults its state machine.
+        """
         provider = _make_provider()
+        # Bridge wraps the bare ALSA player UUID; on_source_selected sets
+        # `_active_player_id` to the bridge and `_in_use_by_queue` to the
+        # queue's underlying bare UUID — they differ when a bridge exists.
+        provider._active_player_id = "spb_bridge1"
         provider._in_use_by_queue = "player1"
 
         await provider._pause_playback()
 
-        provider.mass.players.cmd_pause.assert_awaited_once_with("player1")
+        provider.mass.players.cmd_pause.assert_awaited_once_with("spb_bridge1")
         assert provider._paused_at_player is True
 
     async def test_preserves_in_use_by_queue(self) -> None:
         """The lock stays with the active session — release is the teardown's job."""
         provider = _make_provider()
+        provider._active_player_id = "spb_bridge1"
         provider._in_use_by_queue = "player1"
 
         await provider._pause_playback()
@@ -1826,6 +1840,7 @@ class TestPausePlayback:
         """Pause must not reset the streaming progress mirror."""
         provider = _make_provider()
         provider._streaming_progress_ms = 50_000
+        provider._active_player_id = "spb_bridge1"
         provider._in_use_by_queue = "player1"
 
         await provider._pause_playback()
@@ -1835,6 +1850,7 @@ class TestPausePlayback:
     async def test_no_active_player_is_a_noop(self) -> None:
         """Pause with no active player neither hard-stops nor errors."""
         provider = _make_provider()
+        provider._active_player_id = None
         provider._in_use_by_queue = None
 
         await provider._pause_playback()

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1812,24 +1812,28 @@ class TestPausePlayback:
 
         provider.mass.players.cmd_stop.assert_not_called()
 
-    async def test_calls_queue_pause_with_queue_id(self) -> None:
-        """Pause must target the queue (`player_queues.pause(queue_id)`),
-        not the player. The queue owns the playback_state that MA's UI
-        reads — pausing the underlying player without flipping the queue
-        leaves the UI stuck in "playing".
+    async def test_does_not_call_any_pause_command(self) -> None:
+        """`_pause_playback` must not call cmd_pause / queue.pause / cmd_stop.
+
+        MA's `_handle_cmd_pause` for AudioSource items short-circuits to
+        the plugin's own `on_source_control(PAUSE)` and returns without
+        touching player or queue state. Calling those APIs from us is a
+        no-op (in the best case) or an infinite redirect loop. The
+        user-visible pause is rendered by the silence-keepalive loop in
+        `get_audio_stream` freezing `_stream_metadata.elapsed_time` and
+        by the audio buffer draining into silence — matches the upstream
+        Spotify Connect provider's documented behaviour
+        (`spotify_connect/__init__.py:904-911`).
         """
         provider = _make_provider()
-        # Bridge wraps the bare ALSA player UUID; on_source_selected sets
-        # `_active_player_id` to the bridge and `_in_use_by_queue` to the
-        # queue id (bare UUID). The queue is what we drive.
         provider._active_player_id = "spb_bridge1"
         provider._in_use_by_queue = "player1"
 
         await provider._pause_playback()
 
-        provider.mass.player_queues.pause.assert_awaited_once_with("player1")
         provider.mass.players.cmd_pause.assert_not_called()
-        assert provider._paused_at_player is True
+        provider.mass.players.cmd_stop.assert_not_called()
+        provider.mass.player_queues.pause.assert_not_called()
 
     async def test_preserves_in_use_by_queue(self) -> None:
         """The lock stays with the active session — release is the teardown's job."""
@@ -2234,53 +2238,17 @@ class TestActivatePlayback:
         assert provider._active_player_id == "player1"
         provider.mass.create_task.assert_called()  # type: ignore[unreachable]
 
-    async def test_unpause_edge_calls_queue_play_with_queue_id(self) -> None:
-        """Entering _activate_playback while `_paused_at_player` issues
-        `player_queues.play(queue_id)` so the queue's playback_state flips
-        back to PLAYING.
+    async def test_unpause_edge_does_not_call_play_apis(self) -> None:
+        """Unpause must not invoke cmd_play / queue.play.
+
+        MA never thought we were paused (see TestPausePlayback) so there
+        is nothing to "unpause" on the MA player/queue side. The streaming
+        branch in `get_audio_stream` resumes real audio on its own when
+        `_ynison.state.is_paused` flips back to False. We only clear the
+        diagnostic `_paused_at_player` flag here.
         """
         provider = _make_provider()
         provider._paused_at_player = True
-        provider._active_player_id = "spb_bridge1"
-        provider._in_use_by_queue = "player1"  # queue id
-
-        player = MagicMock()
-        player.player_id = "spb_bridge1"
-        provider.mass.players.all_players.return_value = [player]
-        provider.mass.players.get_player.return_value = player
-
-        state = _make_ynison_state(progress_ms=0, paused=False)
-
-        await provider._activate_playback(state)
-
-        provider.mass.player_queues.play.assert_awaited_once_with("player1")
-        provider.mass.players.cmd_play.assert_not_called()
-        assert provider._paused_at_player is False
-
-    async def test_unpause_edge_clears_flag_even_on_queue_play_failure(self) -> None:
-        """A queue.play exception must not strand `_paused_at_player`."""
-        provider = _make_provider()
-        provider._paused_at_player = True
-        provider._active_player_id = "spb_bridge1"
-        provider._in_use_by_queue = "player1"
-
-        player = MagicMock()
-        player.player_id = "spb_bridge1"
-        provider.mass.players.all_players.return_value = [player]
-        provider.mass.players.get_player.return_value = player
-        provider.mass.player_queues.play = AsyncMock(side_effect=RuntimeError("boom"))
-
-        state = _make_ynison_state(progress_ms=0, paused=False)
-
-        # Must not raise — failure swallowed; flag still cleared.
-        await provider._activate_playback(state)
-
-        assert provider._paused_at_player is False
-
-    async def test_active_playback_no_pause_flag_does_not_call_queue_play(self) -> None:
-        """When we never paused, queue.play must not fire on activation."""
-        provider = _make_provider()
-        provider._paused_at_player = False
         provider._active_player_id = "spb_bridge1"
         provider._in_use_by_queue = "player1"
 
@@ -2294,6 +2262,8 @@ class TestActivatePlayback:
         await provider._activate_playback(state)
 
         provider.mass.player_queues.play.assert_not_called()
+        provider.mass.players.cmd_play.assert_not_called()
+        assert provider._paused_at_player is False
 
     async def test_detects_track_change(self) -> None:
         """Detects track change and updates streaming track id."""

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import asyncio
-from contextlib import suppress
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -1790,40 +1789,15 @@ class TestSendProgressToYnison:
 
 
 class TestPausePlayback:
-    """Tests for _pause_playback under the silence-keepalive contract."""
+    """Tests for _pause_playback under the AriaCast cmd_stop contract."""
 
-    async def test_does_not_set_stop_event(self) -> None:
-        """Pause must keep the generator alive so it can yield silence."""
-        provider = _make_provider()
-        provider._active_player_id = "spb_bridge1"
-        provider._in_use_by_queue = "player1"
+    async def test_sets_stop_event_and_cmd_stops_queue(self) -> None:
+        """External pause must release the player via cmd_stop on the queue id.
 
-        await provider._pause_playback()
-
-        assert not provider._stream_stop_event.is_set()
-
-    async def test_does_not_cmd_stop_the_player(self) -> None:
-        """Pause must not hard-stop the player; the silence loop keeps it live."""
-        provider = _make_provider()
-        provider._active_player_id = "spb_bridge1"
-        provider._in_use_by_queue = "player1"
-
-        await provider._pause_playback()
-
-        provider.mass.players.cmd_stop.assert_not_called()
-
-    async def test_does_not_call_any_pause_command(self) -> None:
-        """`_pause_playback` must not call cmd_pause / queue.pause / cmd_stop.
-
-        MA's `_handle_cmd_pause` for AudioSource items short-circuits to
-        the plugin's own `on_source_control(PAUSE)` and returns without
-        touching player or queue state. Calling those APIs from us is a
-        no-op (in the best case) or an infinite redirect loop. The
-        user-visible pause is rendered by the silence-keepalive loop in
-        `get_audio_stream` freezing `_stream_metadata.elapsed_time` and
-        by the audio buffer draining into silence — matches the upstream
-        Spotify Connect provider's documented behaviour
-        (`spotify_connect/__init__.py:904-911`).
+        Mirrors upstream AriaCast Receiver
+        (`ariacast_receiver/__init__.py:481-490`). The stop event ends
+        the audio generator; cmd_stop flips MA's player/queue state to
+        IDLE so the UI reflects the pause honestly.
         """
         provider = _make_provider()
         provider._active_player_id = "spb_bridge1"
@@ -1831,33 +1805,21 @@ class TestPausePlayback:
 
         await provider._pause_playback()
 
-        provider.mass.players.cmd_pause.assert_not_called()
-        provider.mass.players.cmd_stop.assert_not_called()
-        provider.mass.player_queues.pause.assert_not_called()
+        assert provider._stream_stop_event.is_set()
+        provider.mass.players.cmd_stop.assert_awaited_once_with("player1")
 
-    async def test_preserves_in_use_by_queue(self) -> None:
-        """The lock stays with the active session — release is the teardown's job."""
+    async def test_preserves_active_player_id_for_resume(self) -> None:
+        """`_active_player_id` survives pause so resume can reclaim the same player."""
         provider = _make_provider()
         provider._active_player_id = "spb_bridge1"
         provider._in_use_by_queue = "player1"
 
         await provider._pause_playback()
 
-        assert provider._in_use_by_queue == "player1"
-
-    async def test_preserves_progress(self) -> None:
-        """Pause must not reset the streaming progress mirror."""
-        provider = _make_provider()
-        provider._streaming_progress_ms = 50_000
-        provider._active_player_id = "spb_bridge1"
-        provider._in_use_by_queue = "player1"
-
-        await provider._pause_playback()
-
-        assert provider._streaming_progress_ms == 50_000
+        assert provider._active_player_id == "spb_bridge1"
 
     async def test_no_active_player_is_a_noop(self) -> None:
-        """Pause with no active player neither hard-stops nor errors."""
+        """Pause with no active queue does not call cmd_stop or set the stop event."""
         provider = _make_provider()
         provider._active_player_id = None
         provider._in_use_by_queue = None
@@ -1866,8 +1828,6 @@ class TestPausePlayback:
 
         assert not provider._stream_stop_event.is_set()
         provider.mass.players.cmd_stop.assert_not_called()
-        provider.mass.players.cmd_pause.assert_not_called()
-        assert provider._paused_at_player is False
 
 
 # ------------------------------------------------------------------
@@ -2238,32 +2198,41 @@ class TestActivatePlayback:
         assert provider._active_player_id == "player1"
         provider.mass.create_task.assert_called()  # type: ignore[unreachable]
 
-    async def test_unpause_edge_does_not_call_play_apis(self) -> None:
-        """Unpause must not invoke cmd_play / queue.play.
+    async def test_unpause_after_external_pause_fires_play_media(self) -> None:
+        """Resume after AriaCast-style cmd_stop fires play_media via needs_reselect.
 
-        MA never thought we were paused (see TestPausePlayback) so there
-        is nothing to "unpause" on the MA player/queue side. The streaming
-        branch in `get_audio_stream` resumes real audio on its own when
-        `_ynison.state.is_paused` flips back to False. We only clear the
-        diagnostic `_paused_at_player` flag here.
+        `_pause_playback` sets `_stream_stop_event` and calls `cmd_stop`;
+        the generator exits, `on_source_unselected` clears the lock.
+        When Ynison reports playing again, `_activate_playback` reads
+        `needs_reselect = _stream_stop_event.is_set()` (still True
+        because `_clear_active_player` did NOT run — pause kept the
+        association) and re-issues `play_media`.
         """
         provider = _make_provider()
-        provider._paused_at_player = True
+        # Simulate the post-pause state: stream-stop set, _active_player_id
+        # preserved, _in_use_by_queue cleared by on_source_unselected.
+        provider._stream_stop_event.set()
         provider._active_player_id = "spb_bridge1"
-        provider._in_use_by_queue = "player1"
+        provider._in_use_by_queue = None
 
         player = MagicMock()
         player.player_id = "spb_bridge1"
         provider.mass.players.all_players.return_value = [player]
         provider.mass.players.get_player.return_value = player
 
-        state = _make_ynison_state(progress_ms=0, paused=False)
+        state = _make_ynison_state(progress_ms=10_000, paused=False)
 
         await provider._activate_playback(state)
 
-        provider.mass.player_queues.play.assert_not_called()
-        provider.mass.players.cmd_play.assert_not_called()
-        assert provider._paused_at_player is False
+        # `_activate_playback` schedules `play_media` via `mass.create_task`;
+        # the mass mock's create_task is a MagicMock that does not actually
+        # run the coro. Asserting the scheduling itself is sufficient —
+        # for end-to-end execution see TestPrefetchOrdering which installs
+        # a custom create_task that does run the coro.
+        provider.mass.create_task.assert_called()
+        # Stop event cleared so the next get_audio_stream session runs
+        # normally.
+        assert not provider._stream_stop_event.is_set()
 
     async def test_detects_track_change(self) -> None:
         """Detects track change and updates streaming track id."""
@@ -2620,231 +2589,3 @@ class TestPrefetchOrdering:
         assert order, "expected at least a prefetch call"
         assert order[0].startswith("prefetch:track42")
         assert any(c.startswith("play_media:player1") for c in order[1:])
-
-
-def _make_paused_state(track_id: str = "track42", progress_ms: int = 0) -> YnisonState:
-    """Build a YnisonState marked as paused on `track_id` at `progress_ms`."""
-    state = YnisonState()
-    state.active_device_id = "dev1"
-    state.player_state = {
-        "player_queue": {
-            "playable_list": [{"playable_id": track_id}],
-            "current_playable_index": 0,
-        },
-        "status": {"paused": True, "progress_ms": progress_ms, "duration_ms": 60_000},
-    }
-    return state
-
-
-class TestPauseSilenceKeepalive:
-    """`get_audio_stream` yields PCM silence during pause instead of exiting."""
-
-    async def test_mid_stream_pause_breaks_inner_loop(self) -> None:
-        """A pause arriving mid-track must reroute the generator into silence."""
-        # We exercise the chunk-loop break condition directly: with a paused
-        # Ynison state, the predicate that controls whether to leave
-        # `async for chunk in _stream_track(...)` must evaluate True.
-        provider = _make_provider()
-        ynison = MagicMock()
-        ynison.state.is_paused = True
-        provider._ynison = ynison
-
-        should_break = provider._ynison is not None and provider._ynison.state.is_paused
-        assert should_break
-
-        ynison.state.is_paused = False
-        should_break = provider._ynison is not None and provider._ynison.state.is_paused
-        assert not should_break
-
-    async def test_silence_loop_yields_frame_aligned_zero_pcm(self) -> None:
-        """Driving the generator into the silence branch yields PCM zeros."""
-        provider = _make_provider()
-        # Borrow-mode setup so the generator does not early-return on
-        # _yandex_provider being None.
-        provider._yandex_provider = MagicMock()
-        provider._in_use_by_queue = "queue1"
-        provider._active_session_id = "session-1"
-
-        ynison = MagicMock()
-        ynison.state.is_paused = True
-        ynison.state.current_track_id = "track42"
-        provider._ynison = ynison
-
-        streamdetails = MagicMock()
-        gen = provider.get_audio_stream(streamdetails, seek_position=0)
-
-        async def _flip_to_unpause() -> None:
-            # Give the generator one tick to enter the silence loop, then
-            # also flip is_paused so the loop exits on the next iteration.
-            await asyncio.sleep(0.05)
-            ynison.state.is_paused = False
-            # Setting the event wakes the generator immediately.
-            provider._track_changed_event.set()
-
-        flipper = asyncio.create_task(_flip_to_unpause())
-        chunk = await asyncio.wait_for(gen.__anext__(), timeout=2.0)
-        await flipper
-        # Stop the generator cleanly so the test does not hang.
-        provider._stream_stop_event.set()
-        with suppress(StopAsyncIteration, asyncio.CancelledError):
-            await gen.aclose()
-
-        # Silence is PCM zeros of frame-aligned length.
-        assert chunk
-        assert chunk == b"\x00" * len(chunk)
-        # 100 ms @ 48 kHz / 24-bit / 2ch = 4800 samples × 6 bytes = 28800 bytes
-        # (assumes the default lossless PCM profile; if the hint promoted it,
-        # the chunk would still be a multiple of frame_size).
-        # bytes_per_frame for s24le stereo = 6; for s16le stereo = 4.
-        from provider.streaming import (  # noqa: PLC0415 — local import
-            PCM_LOSSLESS_PARAMS,
-            PCM_LOSSY_PARAMS,
-        )
-
-        expected_frame = max(
-            (PCM_LOSSLESS_PARAMS["bit_depth"] // 8) * PCM_LOSSLESS_PARAMS["channels"],
-            (PCM_LOSSY_PARAMS["bit_depth"] // 8) * PCM_LOSSY_PARAMS["channels"],
-        )
-        assert len(chunk) % expected_frame == 0
-
-    async def test_unpause_seeds_seek_position_from_ynison(self) -> None:
-        """Unpause on the same track must seed `_seek_position_ms` from Ynison."""
-        provider = _make_provider()
-        provider._yandex_provider = MagicMock()
-        provider._in_use_by_queue = "queue1"
-        provider._active_session_id = "session-1"
-
-        ynison = MagicMock()
-        ynison.state.is_paused = True
-        ynison.state.current_track_id = "track42"
-        ynison.state.progress_ms = 42_000
-        provider._ynison = ynison
-
-        # _stream_track captures the seek_ms it receives and then exits so
-        # the outer loop terminates cleanly. The streaming branch sets
-        # `_seek_position_ms = 0` right after reading it, so this is the only
-        # observation point.
-        captured_seek_ms: list[int] = []
-
-        async def _stub_stream_track(
-            _track_id: str, *, seek_ms: int = 0, session_params: dict[str, Any] | None = None
-        ) -> Any:
-            captured_seek_ms.append(seek_ms)
-            provider._stream_stop_event.set()
-            if False:
-                yield b""
-
-        _stub_attr(provider, "_stream_track", _stub_stream_track)
-
-        streamdetails = MagicMock()
-        gen = provider.get_audio_stream(streamdetails, seek_position=0)
-
-        async def _flip_to_unpause() -> None:
-            await asyncio.sleep(0.05)
-            ynison.state.is_paused = False
-            provider._track_changed_event.set()
-
-        flipper = asyncio.create_task(_flip_to_unpause())
-        # Consume silence chunks until the generator falls through the pause
-        # branch and hits the (stubbed) streaming branch which stops it.
-        with suppress(StopAsyncIteration):
-            async for _ in gen:
-                pass
-        await flipper
-        await gen.aclose()
-
-        assert captured_seek_ms == [42_000]
-
-    async def test_long_pause_does_not_exit_generator(self) -> None:
-        """A multi-minute pause keeps the silence loop alive (no deadline)."""
-        provider = _make_provider()
-        provider._yandex_provider = MagicMock()
-        provider._in_use_by_queue = "queue1"
-        provider._active_session_id = "session-1"
-
-        ynison = MagicMock()
-        ynison.state.is_paused = True
-        ynison.state.current_track_id = "track42"
-        provider._ynison = ynison
-
-        streamdetails = MagicMock()
-        gen = provider.get_audio_stream(streamdetails, seek_position=0)
-
-        # Pull a handful of silence chunks across a simulated long span;
-        # the generator must keep yielding without auto-exit.
-        chunks: list[bytes] = []
-        for _ in range(5):
-            chunk = await asyncio.wait_for(gen.__anext__(), timeout=1.0)
-            chunks.append(chunk)
-
-        assert len(chunks) == 5
-        assert all(c == b"\x00" * len(c) for c in chunks)
-
-        # Cleanup: signal stop and close.
-        provider._stream_stop_event.set()
-        with suppress(StopAsyncIteration, asyncio.CancelledError):
-            await gen.aclose()
-
-    async def test_mid_stream_pause_does_not_signal_track_completion(self) -> None:
-        """Regression: pause mid-stream MUST NOT call `_signal_track_completion`.
-
-        Reproduces the "press pause in the app → next track starts" bug: the
-        inner chunk loop breaks on `is_paused`, the code AFTER the inner loop
-        treats every non-`_track_changed_event` exit as natural end-of-track
-        and calls `_signal_track_completion`, which tells Ynison the old
-        track ended → Yandex advances the queue → next track lands.
-        """
-        provider = _make_provider()
-        provider._yandex_provider = MagicMock()
-        provider._in_use_by_queue = "queue1"
-        provider._active_session_id = "session-1"
-
-        ynison = MagicMock()
-        ynison.state.is_paused = False
-        ynison.state.current_track_id = "track42"
-        ynison.state.progress_ms = 13_000
-        provider._ynison = ynison
-
-        # _stream_track yields one chunk, then waits until we flip is_paused
-        # to True so the chunk-loop break condition fires.
-        async def _stub_stream_track(
-            _track_id: str, *, seek_ms: int = 0, session_params: dict[str, Any] | None = None
-        ) -> Any:
-            yield b"\x00\x00\x00\x00"
-            # Give the test a chance to flip is_paused before we yield more.
-            await asyncio.sleep(0.05)
-            yield b"\x00\x00\x00\x00"
-
-        _stub_attr(provider, "_stream_track", _stub_stream_track)
-
-        signal_calls = 0
-
-        async def _spy_signal_completion() -> None:
-            nonlocal signal_calls
-            signal_calls += 1
-
-        _stub_attr(provider, "_signal_track_completion", _spy_signal_completion)
-        # And stop on the next outer-loop turn so the test does not hang.
-        # _signal_track_completion is also what would trigger
-        # _wait_for_track_change; stub it to be a no-op.
-
-        streamdetails = MagicMock()
-        gen = provider.get_audio_stream(streamdetails, seek_position=0)
-
-        async def _flip_to_paused() -> None:
-            await asyncio.sleep(0.02)
-            ynison.state.is_paused = True
-
-        flipper = asyncio.create_task(_flip_to_paused())
-        # Drive the generator: collect the real chunk, then start receiving
-        # silence after the pause flip. Stop after a few silence chunks.
-        chunks: list[bytes] = []
-        for _ in range(3):
-            chunks.append(await asyncio.wait_for(gen.__anext__(), timeout=2.0))
-
-        await flipper
-        provider._stream_stop_event.set()
-        with suppress(StopAsyncIteration, asyncio.CancelledError):
-            await gen.aclose()
-
-        assert signal_calls == 0, "pause must not trigger _signal_track_completion"

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -2728,3 +2728,67 @@ class TestPauseSilenceKeepalive:
         provider._stream_stop_event.set()
         with suppress(StopAsyncIteration, asyncio.CancelledError):
             await gen.aclose()
+
+    async def test_mid_stream_pause_does_not_signal_track_completion(self) -> None:
+        """Regression: pause mid-stream MUST NOT call `_signal_track_completion`.
+
+        Reproduces the "press pause in the app → next track starts" bug: the
+        inner chunk loop breaks on `is_paused`, the code AFTER the inner loop
+        treats every non-`_track_changed_event` exit as natural end-of-track
+        and calls `_signal_track_completion`, which tells Ynison the old
+        track ended → Yandex advances the queue → next track lands.
+        """
+        provider = _make_provider()
+        provider._yandex_provider = MagicMock()
+        provider._in_use_by_queue = "queue1"
+        provider._active_session_id = "session-1"
+
+        ynison = MagicMock()
+        ynison.state.is_paused = False
+        ynison.state.current_track_id = "track42"
+        ynison.state.progress_ms = 13_000
+        provider._ynison = ynison
+
+        # _stream_track yields one chunk, then waits until we flip is_paused
+        # to True so the chunk-loop break condition fires.
+        async def _stub_stream_track(
+            _track_id: str, *, seek_ms: int = 0, session_params: dict[str, Any] | None = None
+        ) -> Any:
+            yield b"\x00\x00\x00\x00"
+            # Give the test a chance to flip is_paused before we yield more.
+            await asyncio.sleep(0.05)
+            yield b"\x00\x00\x00\x00"
+
+        _stub_attr(provider, "_stream_track", _stub_stream_track)
+
+        signal_calls = 0
+
+        async def _spy_signal_completion() -> None:
+            nonlocal signal_calls
+            signal_calls += 1
+
+        _stub_attr(provider, "_signal_track_completion", _spy_signal_completion)
+        # And stop on the next outer-loop turn so the test does not hang.
+        # _signal_track_completion is also what would trigger
+        # _wait_for_track_change; stub it to be a no-op.
+
+        streamdetails = MagicMock()
+        gen = provider.get_audio_stream(streamdetails, seek_position=0)
+
+        async def _flip_to_paused() -> None:
+            await asyncio.sleep(0.02)
+            ynison.state.is_paused = True
+
+        flipper = asyncio.create_task(_flip_to_paused())
+        # Drive the generator: collect the real chunk, then start receiving
+        # silence after the pause flip. Stop after a few silence chunks.
+        chunks: list[bytes] = []
+        for _ in range(3):
+            chunks.append(await asyncio.wait_for(gen.__anext__(), timeout=2.0))
+
+        await flipper
+        provider._stream_stop_event.set()
+        with suppress(StopAsyncIteration, asyncio.CancelledError):
+            await gen.aclose()
+
+        assert signal_calls == 0, "pause must not trigger _signal_track_completion"

--- a/uv.lock
+++ b/uv.lock
@@ -756,11 +756,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]
@@ -942,7 +942,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=7.0" },
     { name = "ruff", marker = "extra == 'test'", specifier = ">=0.14" },
     { name = "syrupy", marker = "extra == 'test'", specifier = ">=5.0" },
-    { name = "ya-passport-auth", specifier = ">=1.3.0" },
+    { name = "ya-passport-auth", specifier = ">=1.4.1" },
 ]
 provides-extras = ["test"]
 
@@ -1106,7 +1106,7 @@ wheels = [
 [[package]]
 name = "music-assistant"
 version = "0.0.0"
-source = { git = "https://github.com/music-assistant/server.git?rev=dev#c9a3a51328023d22451b711d700f225602454982" }
+source = { git = "https://github.com/music-assistant/server.git?rev=dev#d5da69217c5c66cd1691a5c0aa3571dd943fafb1" }
 dependencies = [
     { name = "aiodns" },
     { name = "aiofiles" },
@@ -1152,24 +1152,24 @@ dependencies = [
 
 [[package]]
 name = "music-assistant-frontend"
-version = "2.17.161"
+version = "2.17.165"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/78/d9/01da8642889c1841d8d50c0a285948114fdc791f835f096e276f7c8625cc/music_assistant_frontend-2.17.161.tar.gz", hash = "sha256:ccaed1916d8a09ce9566c8e7a532685921351b0b6d84ab1477554ddb05600369", size = 5177641, upload-time = "2026-05-21T05:11:32.376Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/8a/8880e9279caf5a79b9ba8cb480bd454775f3fe31b0c7b88e630f56ea2434/music_assistant_frontend-2.17.165.tar.gz", hash = "sha256:322dbfc1e5d1fdaf751bec9ac83256b0dbc5f7eb6c9fa5b837b7586e7d765241", size = 5180241, upload-time = "2026-05-26T05:05:54.733Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/c6/cc33a16ea5d69916201884a619ff19560f5d3a99d7998f3c7329bdad6967/music_assistant_frontend-2.17.161-py3-none-any.whl", hash = "sha256:f148e3a506bf79f4a1d4de116c7a73c1819800df665b80431e62cd0542f83bcc", size = 5244458, upload-time = "2026-05-21T05:11:24.079Z" },
+    { url = "https://files.pythonhosted.org/packages/76/e4/623ceb17f5391cdf4ced1f6016024fca9ee265e92910733aa4205789053b/music_assistant_frontend-2.17.165-py3-none-any.whl", hash = "sha256:cb35be4c59c80115b4a87a9f92cfa00c2687471cbadaac2b34c8072660b4083a", size = 5253873, upload-time = "2026-05-26T05:05:52.33Z" },
 ]
 
 [[package]]
 name = "music-assistant-models"
-version = "1.1.121"
+version = "1.1.125"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mashumaro" },
     { name = "orjson" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/31/78/354f6d8d6b2db647a1b7308785150c7bf3d02f958fff4f3f76e80483459a/music_assistant_models-1.1.121.tar.gz", hash = "sha256:7a5e19ca4fb74b496f5ba2466d80d8584a2569e9f385dbeb5749c2794e2ea124", size = 44232, upload-time = "2026-05-22T05:01:40.337Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/4c/caa8e9426a8d92c449775cc59e07decd1aed2635e05811802a6abcc1b854/music_assistant_models-1.1.125.tar.gz", hash = "sha256:4cc5e34376ab41b94afd7b42738e803467196cf9850fba41aab3ceea6a2d820d", size = 46426, upload-time = "2026-05-25T05:20:56.242Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/98/25d9e592e9d4eeb5f40a32dd36743e51a4555aebf416edbcada65d79e764/music_assistant_models-1.1.121-py3-none-any.whl", hash = "sha256:e3ae39dfb24a7f3d6963f6842f15b96062ef7b8fa50e14eab7e6fc7335aefa14", size = 53024, upload-time = "2026-05-22T05:01:38.811Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/da/b88327d1e70c15281981ad54cb4934d3383746b6df9d424ca3cb17b85c1e/music_assistant_models-1.1.125-py3-none-any.whl", hash = "sha256:a8059c8d00230bedabd1cafd78848309f13ad7269d6598eae7aea20bb2607289", size = 54660, upload-time = "2026-05-25T05:20:54.841Z" },
 ]
 
 [[package]]
@@ -2130,15 +2130,15 @@ wheels = [
 
 [[package]]
 name = "ya-passport-auth"
-version = "1.3.0"
+version = "1.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7f/68/079f8773a48d1574e10f8bf32d05e5857db95d59e25178590de2960090db/ya_passport_auth-1.3.0.tar.gz", hash = "sha256:faf764c154755f3ae1b36dc806a727f70165319354d27b8e797dfcbb8e169cc0", size = 54438, upload-time = "2026-04-19T07:23:56.498Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/b6/9f3cd1707b77ea0e85c9f8acc8b0b760243cd8986e618b5158b15fff9207/ya_passport_auth-1.4.1.tar.gz", hash = "sha256:4264feb59bf92ee9dac9b6af3db341b1dc47dbe5897741ec8b405d27156d5739", size = 58051, upload-time = "2026-05-26T09:21:13.935Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/99/8c227da1340b760281f27be58e505fe69291b7d87739260153d3bbe4c9ca/ya_passport_auth-1.3.0-py3-none-any.whl", hash = "sha256:99f94c0011ffa12c3aca144a392d7addae16c2eb1d5f5361fdfdf1d209f86d3c", size = 38227, upload-time = "2026-04-19T07:23:54.697Z" },
+    { url = "https://files.pythonhosted.org/packages/63/74/8c91d4f9040f2d9a6d0d8943dab4ff0a9dacf973f2640ad9b444e8db9a22/ya_passport_auth-1.4.1-py3-none-any.whl", hash = "sha256:a212489df44b7e32e8e2af36daf6c77f50fd6a25e2af3ea1f263f7195452f0f2", size = 39778, upload-time = "2026-05-26T09:21:12.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes a series of issues that surfaced from live testing the AudioSource migration (#67) against upstream MA `dev`:

1. **Preload-path audio buffer fill aborts the queue** — `get_audio_stream` exits immediately because `_in_use_by_queue` is `None` when the streams controller drives the buffer fill before `on_source_selected` has dispatched. MA logs `AudioError: No audio was received` and `Playback failed - no more tracks available`.
2. **`is_streaming_provider` AttributeError** — upstream's audio_analysis providers (Loudness Analysis, Smart Fades) branch on `provider.is_streaming_provider`; `PluginProvider` does not declare it.
3. **Track auto-advance on pause** — pause mid-stream broke the inner chunk loop but the post-loop branch treated every non-track-change exit as natural end and signalled completion → Yandex advanced the queue → wrong track played.
4. **Yandex Music captcha cooldown blocks in-flight streams** — yandex_music's API client engages a 10-min `default` cooldown on first 429-captcha; our `_get_stream_details_with_retry` hits the cooldown wall and fails the stream even when direct yandex_music playback works fine (it uses `BYPASS_THROTTLER` for stream-URL refresh).
5. **External pause doesn't surface to MA UI** — `_handle_cmd_pause` short-circuits any `cmd_pause` / `queue.pause` back to the plugin's own `on_source_control(PAUSE)` for AudioSource items and never flips player/queue state. Audio stops but UI keeps showing "playing".
6. **Resume from external pause crashes with `PlayerUnavailableError`** — `_active_player_id` was the Sendspin bridge (`spb_*`) but queues live on the bare ALSA UUID; `play_media(spb_*, ...)` finds no queue.

## Fixes

| Issue | Fix |
| --- | --- |
| 1 | `had_claim` tracks whether a lock was actually held at generator entry; preload path runs without enforcing the cross-session invariants. |
| 2 | Declare `is_streaming_provider: bool = False` at the class level. |
| 3 | Compute `natural_end` from the full set of break reasons; signal completion only when none fired. |
| 4 | Wrap `_get_stream_details_with_retry` in `BYPASS_THROTTLER` for the in-flight stream path. Same trick as yandex_music's own stream-URL refresh; matches upstream's documented use of the context-var. Prefetch path stays throttled. |
| 5 | Follow the AriaCast Receiver pattern (`ariacast_receiver/__init__.py:481-490`): on external pause, set `_stream_stop_event` and call `cmd_stop(_in_use_by_queue)`. Player → IDLE, queue → IDLE, UI reflects pause correctly. Accepts ~2-3 s of preload+ffmpeg restart on resume (`_activate_playback` reads `needs_reselect = _stream_stop_event.is_set()` → fires `play_media`). |
| 6 | Before cmd_stop, rewrite `_active_player_id = _in_use_by_queue` (queue id, bare UUID). Same fix AriaCast applies (line 485). |

## Investigation notes

The pause UX took several wrong turns before landing on the AriaCast pattern. The commit history preserves each iteration with its reasoning so future maintainers can see why the simpler approaches (silence keep-alive, `cmd_pause` on the bridge, `cmd_pause` on the bare UUID, `mass.player_queues.pause`, frozen `stream_metadata.elapsed_time`) all failed:

- `cmd_pause` and `mass.player_queues.pause` both short-circuit via `_handle_cmd_pause`'s AudioSource branch back to `on_source_control(PAUSE)` — no state ever flips.
- `stream_metadata.elapsed_time` does NOT factor into MA's queue/player `corrected_elapsed_time` extrapolation; the player heartbeat wins. Confirmed by reading `music_assistant_models/player.py:383-389` and `music_assistant_models/player_queue.py:106-113`.
- AriaCast is the only one of the six existing AudioSource providers that surfaces external pause correctly (`spotify_connect/__init__.py:904-911` documents the same gap and accepts a UI-status mismatch).

## Commits

Logical commits, fix-by-fix:

1. `fix(provider): handle preload-path audio buffer fill + audio_analysis attr`
2. `chore: ignore docker-compose.override.yml`
3. `feat(provider)!: silence-keepalive on pause (no hard-stop)` _(approach later replaced)_
4. `fix(provider): pause must not signal track completion`
5. `fix(provider): drive MA player state via cmd_pause / cmd_play` _(later reverted)_
6. `fix(provider): bypass yandex_music throttle on in-flight stream fetch`
7. `fix(provider): cmd_pause and trigger_player_update must target the active player, not the queue id` _(later reverted)_
8. `fix(provider): drive pause/play through player_queues, not players` _(later reverted)_
9. `fix(provider): freeze stream metadata while paused (the only signal AudioSource exposes)` _(approach later replaced)_
10. `fix(provider): republish frozen stream_metadata so the bare player heartbeat does not win` _(approach later replaced)_
11. `fix(provider)!: switch to AriaCast cmd_stop pattern for external pause` _(final approach)_
12. `fix(provider): rewrite _active_player_id to queue id before pause-stop` _(final fix)_

Intermediate commits are preserved (not squashed) because each one captures a real diagnostic step against MA's AudioSource architecture; a future contributor hitting the same UX gap can see what was tried and why each non-AriaCast approach failed.

## Test plan

- [x] `uv run pytest` — **241 passed** (was 239 before this PR).
- [x] `pre-commit run --all-files` — green.
- [x] Live container against MA `dev`: confirmed via Docker logs.
  - Real playback start with Hi-Res FLAC pass-through (48 kHz / 24-bit) ✓
  - Natural track-end → `update_player_state` → next track from Ynison ✓
  - Manual seek from MA UI + Ynison-side seek both correctly detected ✓
  - Pause from Yandex Music app: `cmd_stop` fires, MA UI flips to IDLE, progress freezes ✓
  - Resume from Yandex Music app: `play_media` re-fires, `Streaming track ... seek=<position>` resumes at the right offset within ~2 s ✓
  - Repeat pause/resume cycles work without errors ✓
  - Yandex Music captcha cooldown no longer blocks in-flight stream fetches ✓

## Notes / limitations

- The resume cost is ~2-3 s because MA must redo preload + ffmpeg startup + buffer fill. This matches AriaCast Receiver's behaviour and is the cost of accurate pause-state UI under MA's current AudioSource model. A future upstream patch adding a "report external pause" API for plugins would let us avoid both the silence-keepalive complexity AND the resume cost.
- `docker-compose.override.yml` is now `.gitignore`d; the local dev override installs MA `dev` HEAD on top of the nightly image until a nightly with #3938 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)