### PR TITLE
refactor(auth): adopt the shared ya_passport_auth.ma layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.3.2] - 2026-07-09
+
+### Changed
+
+- The QR login flow and music-token refresh now come from the shared `ya-passport-auth[ma]` layer used by all Music Assistant yandex providers — one implementation to receive fixes.
+
+### Fixed
+
+- Transient Yandex Passport failures (network, rate limiting) during a token refresh no longer read as a login failure — they surface as "temporarily unavailable" so the plugin retries later instead of asking for a new login.
+- Configuration dropdowns (Yandex Music source, target player, output format) stored display names instead of values after a Music Assistant models update, breaking selection persistence.
+
 ## [3.3.1] - 2026-05-29
 
 ### Fixed

--- a/provider/__init__.py
+++ b/provider/__init__.py
@@ -140,9 +140,9 @@ async def get_config_entries(  # noqa: PLR0915 — flow naturally returns ~12 Co
 
     # Build dropdown options: one per YM instance + "Use own credentials" sentinel
     source_options = [
-        ConfigValueOption(f"Yandex Music: {name}", inst_id) for inst_id, name in ym_instances
+        ConfigValueOption(inst_id, f"Yandex Music: {name}") for inst_id, name in ym_instances
     ]
-    source_options.append(ConfigValueOption("Use own credentials (QR or token)", YM_INSTANCE_OWN))
+    source_options.append(ConfigValueOption(YM_INSTANCE_OWN, "Use own credentials (QR or token)"))
 
     # `selected` is normalized above, so it is always either a known instance
     # id (borrowing) or YM_INSTANCE_OWN — safe to use directly as the default.
@@ -244,9 +244,9 @@ async def get_config_entries(  # noqa: PLR0915 — flow naturally returns ~12 Co
             "Set to 'Auto' to automatically select a currently playing player.",
             default_value=PLAYER_ID_AUTO,
             options=[
-                ConfigValueOption("Auto (prefer playing player)", PLAYER_ID_AUTO),
+                ConfigValueOption(PLAYER_ID_AUTO, "Auto (prefer playing player)"),
                 *(
-                    ConfigValueOption(x.display_name, x.player_id)
+                    ConfigValueOption(x.player_id, x.display_name)
                     for x in sorted(
                         mass.players.all_players(False, False),
                         key=lambda p: p.display_name.lower(),
@@ -272,10 +272,10 @@ async def get_config_entries(  # noqa: PLR0915 — flow naturally returns ~12 Co
             "'Auto' selects 44.1 kHz for lossy or 48 kHz for lossless sources.",
             default_value=OUTPUT_AUTO,
             options=[
-                ConfigValueOption("Auto (from source quality)", OUTPUT_AUTO),
-                ConfigValueOption("44100 Hz (CD)", "44100"),
-                ConfigValueOption("48000 Hz", "48000"),
-                ConfigValueOption("96000 Hz (Hi-Res)", "96000"),
+                ConfigValueOption(OUTPUT_AUTO, "Auto (from source quality)"),
+                ConfigValueOption("44100", "44100 Hz (CD)"),
+                ConfigValueOption("48000", "48000 Hz"),
+                ConfigValueOption("96000", "96000 Hz (Hi-Res)"),
             ],
             advanced=True,
         ),
@@ -287,9 +287,9 @@ async def get_config_entries(  # noqa: PLR0915 — flow naturally returns ~12 Co
             "'Auto' selects 16-bit for lossy or 24-bit for lossless sources.",
             default_value=OUTPUT_AUTO,
             options=[
-                ConfigValueOption("Auto (from source quality)", OUTPUT_AUTO),
-                ConfigValueOption("16-bit", "16"),
-                ConfigValueOption("24-bit", "24"),
+                ConfigValueOption(OUTPUT_AUTO, "Auto (from source quality)"),
+                ConfigValueOption("16", "16-bit"),
+                ConfigValueOption("24", "24-bit"),
             ],
             advanced=True,
         ),

--- a/provider/auth.py
+++ b/provider/auth.py
@@ -1,7 +1,7 @@
 """Yandex Passport authentication helpers.
 
-Delegates Passport interactions to the ``ya-passport-auth`` library. Two
-helpers are exposed to the rest of the plugin:
+Thin wrappers over the shared Music Assistant auth layer in
+``ya_passport_auth.ma``. Two helpers are exposed to the rest of the plugin:
 
 * :func:`perform_qr_auth` — full QR login (UI popup → tokens), used by the
   own-mode config flow when the user clicks "Login with QR code".
@@ -15,56 +15,43 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from music_assistant_models.errors import LoginFailed
-from ya_passport_auth import PassportClient, SecretStr
-from ya_passport_auth.exceptions import QRTimeoutError, YaPassportError
+# PassportClient is re-imported here (not used directly) so the test-suite's
+# established patch target `<this module>.PassportClient.create` keeps
+# working — patching the classmethod mutates the class object shared with
+# the ya_passport_auth.ma flows.
+from ya_passport_auth import PassportClient  # noqa: F401
+from ya_passport_auth.ma import refresh_music_token as _refresh_music_token
+from ya_passport_auth.ma import require_music_token, run_qr_flow
 
 if TYPE_CHECKING:
+    from ya_passport_auth import SecretStr
+
     from music_assistant.mass import MusicAssistant
 
 
 async def perform_qr_auth(mass: MusicAssistant, session_id: str) -> tuple[str, str, str | None]:
     """Run a QR login flow and return ``(x_token, music_token, display_login)``.
 
-    Opens the QR popup in the MA frontend via
-    :class:`music_assistant.helpers.auth.AuthenticationHelper`, polls the
-    Yandex Passport endpoint until the user confirms the scan in the Yandex
-    app, then returns the resulting tokens as plain strings (suitable for
-    MA config storage).
+    Opens the QR popup in the MA frontend, polls the Yandex Passport
+    endpoint until the user confirms the scan in the Yandex app, then
+    returns the resulting tokens as plain strings (suitable for MA config
+    storage).
 
     ``display_login`` is the Yandex login name when the server returns it
     (used by the config UI to render "Logged in as X"); may be ``None``.
     """
-    # AuthenticationHelper lives in the music_assistant *server* package,
-    # which isn't always installed in the plugin's standalone test/dev
-    # environment. Lazy import keeps `provider.auth` importable for unit
-    # tests that don't exercise this code path.
-    from music_assistant.helpers.auth import AuthenticationHelper  # noqa: PLC0415
-
-    try:
-        async with PassportClient.create() as client:
-            qr = await client.start_qr_login()
-            async with AuthenticationHelper(mass, session_id) as auth_helper:
-                auth_helper.send_url(qr.qr_url)
-                creds = await client.poll_qr_until_confirmed(qr)
-
-            if creds.music_token is None:
-                raise LoginFailed("QR auth succeeded but no music token was returned")
-            return (
-                creds.x_token.get_secret(),
-                creds.music_token.get_secret(),
-                creds.display_login,
-            )
-    except QRTimeoutError as err:
-        raise LoginFailed("QR authentication timed out. Please try again.") from err
-    except YaPassportError as err:
-        raise LoginFailed(f"Yandex auth error: {err}") from err
+    result = await run_qr_flow(mass, session_id)
+    creds = result.credentials
+    music_token = require_music_token(creds, flow="QR")
+    return (creds.x_token.get_secret(), music_token, result.display_login or None)
 
 
 async def refresh_music_token(x_token: SecretStr) -> SecretStr:
-    """Exchange an x_token for a fresh music-scoped OAuth token."""
-    try:
-        async with PassportClient.create() as client:
-            return await client.refresh_music_token(x_token)
-    except YaPassportError as err:
-        raise LoginFailed(f"Failed to refresh music token: {err}") from err
+    """Exchange an x_token for a fresh music-scoped OAuth token.
+
+    Transient Passport failures (network, rate limiting) raise
+    ``ResourceTemporarilyUnavailable`` so callers retry later instead of
+    treating a hiccup as dead credentials; only an explicit rejection
+    raises ``LoginFailed``.
+    """
+    return await _refresh_music_token(x_token)

--- a/provider/manifest.json
+++ b/provider/manifest.json
@@ -5,7 +5,7 @@
   "name": "Yandex Music Connect (Ynison)",
   "description": "Makes a Music Assistant player appear as a device in the Yandex Music app via the Ynison protocol.",
   "codeowners": ["@TrudenBoy"],
-  "requirements": ["ya-passport-auth==1.5.0"],
+  "requirements": ["ya-passport-auth[ma]==1.6.0"],
   "depends_on": "yandex_music",
   "documentation": "https://music-assistant.io/plugins/yandex-ynison/",
   "multi_instance": true

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -770,8 +770,11 @@ class YandexYnisonProvider(PluginProvider):
             token. Hashed before use as a cache key; the raw value is
             never stored in dict keys or logs.
         :returns: Fresh or cached music-scoped :class:`SecretStr`.
-        :raises LoginFailed: When the underlying refresh fails (propagated
-            from :func:`provider.auth.refresh_music_token`).
+        :raises LoginFailed: When Yandex explicitly rejects the x_token
+            (propagated from :func:`provider.auth.refresh_music_token`).
+        :raises ResourceTemporarilyUnavailable: On transient Passport
+            failures (network, rate limit) — retry later, credentials
+            are still good.
         """
         cache_key = _hash_x_token(x_token)
         cached = self._token_cache.get(cache_key)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -44,7 +44,7 @@ async def test_refresh_music_token_auth_error_raises_login_failed() -> None:
         mock_create.return_value.__aenter__ = mock.AsyncMock(return_value=mock_client)
         mock_create.return_value.__aexit__ = mock.AsyncMock(return_value=False)
 
-        with pytest.raises(LoginFailed, match="Failed to refresh"):
+        with pytest.raises(LoginFailed, match="Music token refresh was rejected"):
             await refresh_music_token(SecretStr("bad_x_token"))
 
 
@@ -155,7 +155,7 @@ async def test_perform_qr_auth_passport_error_maps_to_login_failed() -> None:
     p1 = _patched_passport(client)
     p2, _helper = _patched_auth_helper()
     try:
-        with pytest.raises(LoginFailed, match="Yandex auth error"):
+        with pytest.raises(LoginFailed, match="QR authentication failed"):
             await perform_qr_auth(mock.MagicMock(), "session-1")
     finally:
         p1.stop()


### PR DESCRIPTION
Phase 2E of the auth-unification plan (companions: trudenboy/ya-passport-auth#55, music#204, station#97; needs trudenboy/ma-provider-tools#107 distributed for CI).

- `perform_qr_auth` / `refresh_music_token` delegate to `ya-passport-auth[ma]==1.6.0`; the plugin gains the transient/terminal error distinction it previously lacked (a Passport hiccup no longer clears the login) and session-id validation on the QR flow.
- Fixes a latent `ConfigValueOption` regression surfaced by the `music-assistant-models` upgrade the `[ma]` extra brings in (positional fields swapped to `(value, title)`): the YM-source, target-player and output-format dropdowns stored display names as values. Same fix as station#91.

286 tests pass; ruff clean. No spec required: `refactor:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)