### PR TITLE
fix: upstream dev lint parity (strings.json config texts, ruff 0.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+- refactor(config): move every `ConfigEntry` label/description/action_label and all static `ConfigValueOption` titles into `provider/strings.json` (upstream `check_config_entries` compliance); `ConfigValueOption` calls are now value-only.
+- fix(lint): annotate `_RADIO_ENTITY_TYPES` as `ClassVar` (RUF012) and await the echo-simulation task in `test_provider.py` (RUF006), per the upstream dev ruff rules.
+- style: ruff 0.15 safe autofixes matching the upstream dev lint rules.
+
 ## [3.3.3] - 2026-07-09
 
 ### Changed

--- a/provider/__init__.py
+++ b/provider/__init__.py
@@ -142,7 +142,7 @@ async def get_config_entries(  # noqa: PLR0915 — flow naturally returns ~12 Co
     source_options = [
         ConfigValueOption(inst_id, f"Yandex Music: {name}") for inst_id, name in ym_instances
     ]
-    source_options.append(ConfigValueOption(YM_INSTANCE_OWN, "Use own credentials (QR or token)"))
+    source_options.append(ConfigValueOption(YM_INSTANCE_OWN))
 
     # `selected` is normalized above, so it is always either a known instance
     # id (borrowing) or YM_INSTANCE_OWN — safe to use directly as the default.
@@ -163,11 +163,6 @@ async def get_config_entries(  # noqa: PLR0915 — flow naturally returns ~12 Co
         ConfigEntry(
             key=CONF_YM_INSTANCE,
             type=ConfigEntryType.STRING,
-            label="Yandex Music source",
-            description="Borrow OAuth credentials from a linked Yandex Music provider "
-            "instance, or use your own credentials (QR-scan login or manual token paste). "
-            "Per-instance own credentials let you bind separate players to separate "
-            "Yandex accounts without sharing tokens with a Yandex Music provider.",
             options=source_options,
             default_value=dropdown_default,
             required=True,
@@ -176,21 +171,13 @@ async def get_config_entries(  # noqa: PLR0915 — flow naturally returns ~12 Co
         ConfigEntry(
             key=CONF_ACTION_AUTH_QR,
             type=ConfigEntryType.ACTION,
-            label="Login with QR code",
-            description="Open a QR code in a popup and scan it with the Yandex app on "
-            "your phone. Populates the token automatically — no manual paste needed.",
             action=CONF_ACTION_AUTH_QR,
-            action_label="Login with QR code",
             hidden=own_hidden or own_authenticated,
         ),
         # Own-mode: remember-session toggle
         ConfigEntry(
             key=CONF_REMEMBER_SESSION,
             type=ConfigEntryType.BOOLEAN,
-            label="Remember session (auto-refresh token)",
-            description="Store a long-lived session token (x_token) alongside the music "
-            "token so this plugin can refresh on its own when the token expires. "
-            "Disable to keep only the short-lived music token (re-QR required on expiry).",
             default_value=True,
             hidden=own_hidden or own_authenticated,
         ),
@@ -198,20 +185,12 @@ async def get_config_entries(  # noqa: PLR0915 — flow naturally returns ~12 Co
         ConfigEntry(
             key=CONF_ACTION_CLEAR_AUTH,
             type=ConfigEntryType.ACTION,
-            label="Reset authentication",
-            description="Clear the current authentication details "
-            "(music token, session token, and stored login).",
             action=CONF_ACTION_CLEAR_AUTH,
-            action_label="Reset authentication",
             hidden=own_hidden or not own_authenticated,
         ),
         ConfigEntry(
             key=CONF_TOKEN,
             type=ConfigEntryType.SECURE_STRING,
-            label="Yandex Music Token",
-            description="Manually pasted Yandex Music OAuth token. Populated "
-            "automatically after a successful QR login; only fill in by hand if "
-            "you can't use QR (e.g. headless setup).",
             required=token_required,
             hidden=borrowing,
             value=cast("str", values.get(CONF_TOKEN)) if values else None,
@@ -220,7 +199,6 @@ async def get_config_entries(  # noqa: PLR0915 — flow naturally returns ~12 Co
         ConfigEntry(
             key=CONF_X_TOKEN,
             type=ConfigEntryType.SECURE_STRING,
-            label="Session token (x_token)",
             hidden=True,
             required=False,
             value=cast("str", values.get(CONF_X_TOKEN)) if values else None,
@@ -229,7 +207,6 @@ async def get_config_entries(  # noqa: PLR0915 — flow naturally returns ~12 Co
         ConfigEntry(
             key=CONF_ACCOUNT_LOGIN,
             type=ConfigEntryType.STRING,
-            label="Account login",
             hidden=True,
             required=False,
             value=cast("str", values.get(CONF_ACCOUNT_LOGIN)) if values else None,
@@ -237,14 +214,9 @@ async def get_config_entries(  # noqa: PLR0915 — flow naturally returns ~12 Co
         ConfigEntry(
             key=CONF_MASS_PLAYER_ID,
             type=ConfigEntryType.STRING,
-            label="Connected Music Assistant Player",
-            description="The Music Assistant player connected to this Ynison plugin. "
-            "When playback is directed to this device in the Yandex Music app, "
-            "the audio will play on the selected player. "
-            "Set to 'Auto' to automatically select a currently playing player.",
             default_value=PLAYER_ID_AUTO,
             options=[
-                ConfigValueOption(PLAYER_ID_AUTO, "Auto (prefer playing player)"),
+                ConfigValueOption(PLAYER_ID_AUTO),
                 *(
                     ConfigValueOption(x.player_id, x.display_name)
                     for x in sorted(
@@ -258,52 +230,39 @@ async def get_config_entries(  # noqa: PLR0915 — flow naturally returns ~12 Co
         ConfigEntry(
             key=CONF_ALLOW_PLAYER_SWITCH,
             type=ConfigEntryType.BOOLEAN,
-            label="Allow manual player switching",
-            description="When enabled, you can select this plugin as a source on any player "
-            "to switch playback to that player. When disabled, playback is fixed to the "
-            "configured default player.",
             default_value=True,
         ),
         ConfigEntry(
             key=CONF_OUTPUT_SAMPLE_RATE,
             type=ConfigEntryType.STRING,
-            label="Output sample rate",
-            description="Sample rate for PCM output to the player. "
-            "'Auto' selects 44.1 kHz for lossy or 48 kHz for lossless sources.",
             default_value=OUTPUT_AUTO,
             options=[
-                ConfigValueOption(OUTPUT_AUTO, "Auto (from source quality)"),
-                ConfigValueOption("44100", "44100 Hz (CD)"),
-                ConfigValueOption("48000", "48000 Hz"),
-                ConfigValueOption("96000", "96000 Hz (Hi-Res)"),
+                ConfigValueOption(OUTPUT_AUTO),
+                ConfigValueOption("44100"),
+                ConfigValueOption("48000"),
+                ConfigValueOption("96000"),
             ],
             advanced=True,
         ),
         ConfigEntry(
             key=CONF_OUTPUT_BIT_DEPTH,
             type=ConfigEntryType.STRING,
-            label="Output bit depth",
-            description="Bit depth for PCM output to the player. "
-            "'Auto' selects 16-bit for lossy or 24-bit for lossless sources.",
             default_value=OUTPUT_AUTO,
             options=[
-                ConfigValueOption(OUTPUT_AUTO, "Auto (from source quality)"),
-                ConfigValueOption("16", "16-bit"),
-                ConfigValueOption("24", "24-bit"),
+                ConfigValueOption(OUTPUT_AUTO),
+                ConfigValueOption("16"),
+                ConfigValueOption("24"),
             ],
             advanced=True,
         ),
         ConfigEntry(
             key=CONF_PUBLISH_NAME,
             type=ConfigEntryType.STRING,
-            label="Device name in Yandex Music",
-            description="How this device appears in the Yandex Music app.",
             default_value=DEFAULT_DISPLAY_NAME,
         ),
         ConfigEntry(
             key=CONF_DEVICE_ID,
             type=ConfigEntryType.STRING,
-            label="Device ID",
             hidden=True,
             required=False,
         ),

--- a/provider/auth.py
+++ b/provider/auth.py
@@ -1,4 +1,5 @@
-"""Yandex Passport authentication helpers.
+"""
+Yandex Passport authentication helpers.
 
 Thin wrappers over the shared Music Assistant auth layer in
 ``ya_passport_auth.ma``. Two helpers are exposed to the rest of the plugin:
@@ -30,7 +31,8 @@ if TYPE_CHECKING:
 
 
 async def perform_qr_auth(mass: MusicAssistant, session_id: str) -> tuple[str, str, str | None]:
-    """Run a QR login flow and return ``(x_token, music_token, display_login)``.
+    """
+    Run a QR login flow and return ``(x_token, music_token, display_login)``.
 
     Opens the QR popup in the MA frontend, polls the Yandex Passport
     endpoint until the user confirms the scan in the Yandex app, then
@@ -47,7 +49,8 @@ async def perform_qr_auth(mass: MusicAssistant, session_id: str) -> tuple[str, s
 
 
 async def refresh_music_token(x_token: SecretStr) -> SecretStr:
-    """Exchange an x_token for a fresh music-scoped OAuth token.
+    """
+    Exchange an x_token for a fresh music-scoped OAuth token.
 
     Transient Passport failures (network, rate limiting) raise
     ``ResourceTemporarilyUnavailable`` so callers retry later instead of

--- a/provider/protocols.py
+++ b/provider/protocols.py
@@ -1,4 +1,5 @@
-"""Protocol definitions for provider dependencies.
+"""
+Protocol definitions for provider dependencies.
 
 Allows typing of external provider references without importing concrete classes.
 """
@@ -15,7 +16,8 @@ if TYPE_CHECKING:
 
 @runtime_checkable
 class YandexMusicProviderLike(Protocol):
-    """Structural interface for the yandex_music MusicProvider.
+    """
+    Structural interface for the yandex_music MusicProvider.
 
     Only the subset of methods/properties used by the Ynison plugin.
     """

--- a/provider/provider.py
+++ b/provider/provider.py
@@ -9,7 +9,7 @@ import time
 from collections.abc import AsyncGenerator, Callable
 from contextlib import suppress
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 
 from music_assistant_models.enums import (
     ContentType,
@@ -124,7 +124,8 @@ _VALID_BIT_DEPTHS: frozenset[str] = frozenset({"16", "24"})
 
 @dataclass(frozen=True)
 class _CachedToken:
-    """Music token entry in the in-memory cache.
+    """
+    Music token entry in the in-memory cache.
 
     `expires_monotonic` is compared against the provider's `_now()` seam.
     """
@@ -134,7 +135,8 @@ class _CachedToken:
 
 
 def _hash_x_token(x_token: str) -> str:
-    """Return the SHA-256 hex digest of an x_token, used as cache key.
+    """
+    Return the SHA-256 hex digest of an x_token, used as cache key.
 
     The raw x_token is never stored in dict keys (defence-in-depth against
     accidental log / dump leakage of the cache structure).
@@ -355,7 +357,8 @@ class YandexYnisonProvider(PluginProvider):
         return [self._audio_source]
 
     async def get_stream_details(self, source_id: str, queue_id: str) -> StreamDetails:
-        """Return StreamDetails for streaming the Yandex Music Connect audio.
+        """
+        Return StreamDetails for streaming the Yandex Music Connect audio.
 
         Side-effect-free: ownership is claimed in on_source_selected (which the
         streams controller fires before this method on the actual stream
@@ -400,7 +403,8 @@ class YandexYnisonProvider(PluginProvider):
     async def get_audio_stream(  # noqa: PLR0915
         self, streamdetails: StreamDetails, seek_position: int = 0
     ) -> AsyncGenerator[bytes]:
-        """Return continuous audio stream following Ynison track changes.
+        """
+        Return continuous audio stream following Ynison track changes.
 
         Streams the current track, then waits for track changes and streams
         the next track automatically. Runs until the source is deselected.
@@ -635,7 +639,8 @@ class YandexYnisonProvider(PluginProvider):
             self._in_use_by_queue = None
 
     async def _wait_for_track_change(self, old_track_id: str, timeout: float = 30.0) -> bool:
-        """Wait for Ynison to report a different track, ignoring echoes.
+        """
+        Wait for Ynison to report a different track, ignoring echoes.
 
         After _signal_track_completion sends update_playing_status, Ynison
         echoes back the same track with updated progress.  Only return True
@@ -670,7 +675,8 @@ class YandexYnisonProvider(PluginProvider):
         seek_ms: int = 0,
         session_params: dict[str, Any] | None = None,
     ) -> AsyncGenerator[bytes]:
-        """Stream a single track, normalizing to fixed PCM via per-track ffmpeg.
+        """
+        Stream a single track, normalizing to fixed PCM via per-track ffmpeg.
 
         Every track is decoded through its own ffmpeg process to produce a
         fixed PCM output (s16le or s24le based on YM quality setting). This
@@ -823,7 +829,8 @@ class YandexYnisonProvider(PluginProvider):
     # ------------------------------------------------------------------
 
     async def _refresh_via_x_token(self, x_token: str) -> SecretStr:
-        """Refresh the music token from an x_token, caching the result.
+        """
+        Refresh the music token from an x_token, caching the result.
 
         Within :data:`_MUSIC_TOKEN_TTL_S` of a successful refresh, subsequent
         calls for the same x_token return the cached :class:`SecretStr`
@@ -860,7 +867,8 @@ class YandexYnisonProvider(PluginProvider):
             return token
 
     def _store_cached_token(self, cache_key: str, token: SecretStr) -> None:
-        """Insert a cache entry, enforcing the LRU bound.
+        """
+        Insert a cache entry, enforcing the LRU bound.
 
         Refreshing an existing key bumps its position to most-recent. When
         a new key would push the cache over :data:`_MUSIC_TOKEN_CACHE_MAX`,
@@ -882,7 +890,8 @@ class YandexYnisonProvider(PluginProvider):
         self._token_cache.pop(_hash_x_token(x_token), None)
 
     async def _resolve_token(self) -> SecretStr:
-        """Resolve the Yandex Music OAuth token for the Ynison connection.
+        """
+        Resolve the Yandex Music OAuth token for the Ynison connection.
 
         In borrow mode: read from the linked yandex_music provider's config.
         If only x_token is present (YM hasn't refreshed yet), do a cached
@@ -904,7 +913,8 @@ class YandexYnisonProvider(PluginProvider):
         raise LoginFailed("No Yandex Music token configured")
 
     async def _refresh_ynison_token(self) -> SecretStr:
-        """Refresh the OAuth token for Ynison reconnection.
+        """
+        Refresh the OAuth token for Ynison reconnection.
 
         Called by YnisonClient on auth failure (401/403) during reconnect.
 
@@ -1177,7 +1187,8 @@ class YandexYnisonProvider(PluginProvider):
         *,
         strict: bool = False,
     ) -> None:
-        """Send progress to Ynison.
+        """
+        Send progress to Ynison.
 
         Progress is clamped to duration because Ynison rejects updates where
         progress > duration (error 400030001) and disconnects the WebSocket.
@@ -1240,7 +1251,8 @@ class YandexYnisonProvider(PluginProvider):
         )
 
     async def _pause_playback(self) -> None:
-        """Release the active player on external pause.
+        """
+        Release the active player on external pause.
 
         ``cmd_stop`` is the only mechanism that flips ``PlaybackState``
         to IDLE for an AudioSource queue item; ``cmd_pause`` and
@@ -1315,7 +1327,8 @@ class YandexYnisonProvider(PluginProvider):
         return None
 
     def _session_lost(self, player_id: str, session_id: str | None) -> bool:
-        """Return ``True`` when our claim no longer matches the live session.
+        """
+        Return ``True`` when our claim no longer matches the live session.
 
         :param player_id: Queue id captured at generator entry.
         :param session_id: ``_active_session_id`` captured at generator entry.
@@ -1323,7 +1336,8 @@ class YandexYnisonProvider(PluginProvider):
         return self._in_use_by_queue != player_id or self._active_session_id != session_id
 
     def _idempotent(self, action: str, key: str | None) -> bool:
-        """Return ``True`` if ``(action, key)`` was not seen within the TTL window.
+        """
+        Return ``True`` if ``(action, key)`` was not seen within the TTL window.
 
         :param action: A short string identifying the command kind.
         :param key: Sub-key inside the action namespace, or ``None``.
@@ -1346,7 +1360,8 @@ class YandexYnisonProvider(PluginProvider):
         our_ms: int,
         threshold_ms: int = 3000,
     ) -> Literal["ignore", "queue_rebuild", "seek"]:
-        """Classify drift between Ynison-reported and our local position.
+        """
+        Classify drift between Ynison-reported and our local position.
 
         Returns one of:
 
@@ -1369,7 +1384,8 @@ class YandexYnisonProvider(PluginProvider):
         return "seek"
 
     async def _prefetch_format_for_track(self, track_id: str) -> None:
-        """Pre-fetch stream details for *track_id* and adapt PCM format.
+        """
+        Pre-fetch stream details for *track_id* and adapt PCM format.
 
         Best-effort: bounded by ``_PREFETCH_FORMAT_TIMEOUT`` so a slow Yandex
         API does not stall ``_activate_playback``. On timeout / error the
@@ -1449,7 +1465,8 @@ class YandexYnisonProvider(PluginProvider):
         self.mass.create_task(self._check_yandex_provider_match())
 
     async def _check_yandex_provider_match(self) -> None:
-        """Check if a Yandex Music provider is available for audio streaming.
+        """
+        Check if a Yandex Music provider is available for audio streaming.
 
         In borrow mode (self._ym_instance_id set), match strictly by instance_id
         so that audio and credentials come from the same account. In own mode,
@@ -1474,7 +1491,8 @@ class YandexYnisonProvider(PluginProvider):
             self._update_source_capabilities()
 
     def _snap_rate_to_player(self, rate: int) -> int:
-        """Snap *rate* down to the nearest sample rate the target player accepts.
+        """
+        Snap *rate* down to the nearest sample rate the target player accepts.
 
         Best-effort: returns *rate* unchanged when no target player or
         supported-rate set can be resolved, and never raises.
@@ -1506,7 +1524,8 @@ class YandexYnisonProvider(PluginProvider):
             return rate
 
     def _update_normalized_format(self, hint: AudioFormat | None = None) -> None:
-        """Set PCM normalization profile based on config and YM quality.
+        """
+        Set PCM normalization profile based on config and YM quality.
 
         Priority: explicit config values > hint from real stream_details >
         auto-detection from YM quality. The hint is fed by
@@ -1688,7 +1707,8 @@ class YandexYnisonProvider(PluginProvider):
         return 0
 
     def _require_connected_ynison(self) -> YnisonClient:
-        """Return the live Ynison client or raise an MA player-control error.
+        """
+        Return the live Ynison client or raise an MA player-control error.
 
         :raises UnsupportedFeaturedException: When the provider's Ynison
             client has not been initialised yet (pre-`handle_async_init`
@@ -1740,7 +1760,7 @@ class YandexYnisonProvider(PluginProvider):
     # Currently only RADIO (personal wave, genre stations).
     # Add "WAVE" here if/when Yandex supports it via the same
     # rotor_station_tracks API.
-    _RADIO_ENTITY_TYPES = {"RADIO"}
+    _RADIO_ENTITY_TYPES: ClassVar[set[str]] = {"RADIO"}
 
     def _maybe_prefetch(
         self,
@@ -1781,7 +1801,8 @@ class YandexYnisonProvider(PluginProvider):
         self._prefetch_task = self.mass.create_task(_do_prefetch())
 
     async def _signal_track_completion(self) -> None:
-        """Signal that the current track finished playing.
+        """
+        Signal that the current track finished playing.
 
         Ynison is a state-sync protocol — the active device must advance
         current_playable_index itself.
@@ -1884,7 +1905,8 @@ class YandexYnisonProvider(PluginProvider):
         entity_type: str,
         playable_list: list[dict[str, Any]],
     ) -> list[dict[str, Any]] | None:
-        """Fetch more tracks from Yandex Music API and return expanded playable_list.
+        """
+        Fetch more tracks from Yandex Music API and return expanded playable_list.
 
         The active device is responsible for replenishing RADIO/wave queues.
         Ynison only syncs state — it does NOT generate new tracks.
@@ -1957,7 +1979,8 @@ class YandexYnisonProvider(PluginProvider):
         *,
         expanded_list: list[dict[str, Any]] | None = None,
     ) -> None:
-        """Send update_player_state to advance the queue to next_index.
+        """
+        Send update_player_state to advance the queue to next_index.
 
         If expanded_list is provided, it replaces the playable_list
         (used after radio queue replenishment).
@@ -2003,7 +2026,8 @@ class YandexYnisonProvider(PluginProvider):
             )
 
     async def _update_queue_list(self, expanded_list: list[dict[str, Any]]) -> None:
-        """Push an expanded playable_list to Ynison without changing index or progress.
+        """
+        Push an expanded playable_list to Ynison without changing index or progress.
 
         Called right after prefetch completes so the YM app sees upcoming
         tracks and enables the "next" button.
@@ -2034,7 +2058,8 @@ class YandexYnisonProvider(PluginProvider):
             await self._advance_queue_index(current_index - 1)
 
     async def _on_seek(self, position: int) -> None:
-        """Handle seek command — send position update to Ynison.
+        """
+        Handle seek command — send position update to Ynison.
 
         :param position: Position in seconds from Music Assistant.
         """

--- a/provider/streaming.py
+++ b/provider/streaming.py
@@ -1,4 +1,5 @@
-"""PCM normalization helpers for Yandex Music audio streams.
+"""
+PCM normalization helpers for Yandex Music audio streams.
 
 Contains format profiles, the AudioFormat factory, and ffmpeg probe args.
 """

--- a/provider/strings.json
+++ b/provider/strings.json
@@ -1,0 +1,72 @@
+{
+  "config_entries": {
+    "ym_instance": {
+      "label": "Yandex Music source",
+      "description": "Borrow OAuth credentials from a linked Yandex Music provider instance, or use your own credentials (QR-scan login or manual token paste). Per-instance own credentials let you bind separate players to separate Yandex accounts without sharing tokens with a Yandex Music provider.",
+      "options": {
+        "__own__": "Use own credentials (QR or token)"
+      }
+    },
+    "auth_qr": {
+      "label": "Login with QR code",
+      "description": "Open a QR code in a popup and scan it with the Yandex app on your phone. Populates the token automatically — no manual paste needed.",
+      "action_label": "Login with QR code"
+    },
+    "remember_session": {
+      "label": "Remember session (auto-refresh token)",
+      "description": "Store a long-lived session token (x_token) alongside the music token so this plugin can refresh on its own when the token expires. Disable to keep only the short-lived music token (re-QR required on expiry)."
+    },
+    "clear_auth": {
+      "label": "Reset authentication",
+      "description": "Clear the current authentication details (music token, session token, and stored login).",
+      "action_label": "Reset authentication"
+    },
+    "token": {
+      "label": "Yandex Music Token",
+      "description": "Manually pasted Yandex Music OAuth token. Populated automatically after a successful QR login; only fill in by hand if you can't use QR (e.g. headless setup)."
+    },
+    "x_token": {
+      "label": "Session token (x_token)"
+    },
+    "account_login": {
+      "label": "Account login"
+    },
+    "device_id": {
+      "label": "Device ID"
+    },
+    "mass_player_id": {
+      "label": "Connected Music Assistant Player",
+      "description": "The Music Assistant player connected to this Ynison plugin. When playback is directed to this device in the Yandex Music app, the audio will play on the selected player. Set to 'Auto' to automatically select a currently playing player.",
+      "options": {
+        "__auto__": "Auto (prefer playing player)"
+      }
+    },
+    "allow_player_switch": {
+      "label": "Allow manual player switching",
+      "description": "When enabled, you can select this plugin as a source on any player to switch playback to that player. When disabled, playback is fixed to the configured default player."
+    },
+    "output_sample_rate": {
+      "label": "Output sample rate",
+      "description": "Sample rate for PCM output to the player. 'Auto' selects 44.1 kHz for lossy or 48 kHz for lossless sources.",
+      "options": {
+        "auto": "Auto (from source quality)",
+        "44100": "44100 Hz (CD)",
+        "48000": "48000 Hz",
+        "96000": "96000 Hz (Hi-Res)"
+      }
+    },
+    "output_bit_depth": {
+      "label": "Output bit depth",
+      "description": "Bit depth for PCM output to the player. 'Auto' selects 16-bit for lossy or 24-bit for lossless sources.",
+      "options": {
+        "auto": "Auto (from source quality)",
+        "16": "16-bit",
+        "24": "24-bit"
+      }
+    },
+    "publish_name": {
+      "label": "Device name in Yandex Music",
+      "description": "How this device appears in the Yandex Music app."
+    }
+  }
+}

--- a/provider/ynison_client.py
+++ b/provider/ynison_client.py
@@ -35,7 +35,8 @@ from .constants import (
 
 
 class YnisonSendError(ConnectionError):
-    """Raised by `YnisonClient._send(strict=True)` when a send cannot reach Ynison.
+    """
+    Raised by `YnisonClient._send(strict=True)` when a send cannot reach Ynison.
 
     Indicates a transport-level failure (WebSocket not connected, write raised
     ``ConnectionError`` / ``aiohttp.ClientError`` / ``RuntimeError`` / ``OSError``).
@@ -49,7 +50,8 @@ class YnisonSendError(ConnectionError):
 
 
 def make_version_block(device_id: str) -> dict[str, Any]:
-    """Build a version sub-object authored by the given device.
+    """
+    Build a version sub-object authored by the given device.
 
     Ynison expects string types for version and timestamp fields;
     passing integers triggers 500 responses that terminate the WebSocket.
@@ -72,7 +74,8 @@ def _stringify_version(version: Any) -> None:
 
 
 def normalize_player_state_timestamps(player_state: dict[str, Any]) -> None:
-    """Coerce Ynison timestamp fields to strings in-place.
+    """
+    Coerce Ynison timestamp fields to strings in-place.
 
     Ynison rejects integer `status.progress_ms`/`duration_ms`/`version.*`
     (HTTP 500 + WS teardown), so we normalize inbound state at the ingestion
@@ -153,7 +156,8 @@ AuthRefreshCallback = Callable[[], Awaitable["SecretStr"]]
 
 
 class YnisonClient:
-    """WebSocket client for the Yandex Ynison protocol.
+    """
+    WebSocket client for the Yandex Ynison protocol.
 
     Manages the two-step connection (redirector → state service) and
     provides methods to send state updates back to Ynison.
@@ -168,7 +172,8 @@ class YnisonClient:
         http_session: aiohttp.ClientSession | None = None,
         on_auth_failure: AuthRefreshCallback | None = None,
     ) -> None:
-        """Initialize Ynison client.
+        """
+        Initialize Ynison client.
 
         :param token: Yandex Music OAuth token (wrapped in SecretStr).
         :param device_info: Device identification for Ynison.
@@ -211,7 +216,8 @@ class YnisonClient:
 
     @property
     def in_post_reconnect_settle(self) -> bool:
-        """True iff we're inside the 2 s post-reconnect settle window.
+        """
+        True iff we're inside the 2 s post-reconnect settle window.
 
         Provider handlers consult this to skip the first inbound state right
         after a reconnect — that state can be a stale broadcast of our own
@@ -226,7 +232,8 @@ class YnisonClient:
         return self._device_info.device_id
 
     async def connect(self) -> None:
-        """Connect to Ynison (redirector → state service).
+        """
+        Connect to Ynison (redirector → state service).
 
         Raises on auth failure; auto-reconnects on transient errors.
         """
@@ -298,7 +305,8 @@ class YnisonClient:
         *,
         strict: bool = False,
     ) -> None:
-        """Send playback status update to Ynison.
+        """
+        Send playback status update to Ynison.
 
         :param progress_ms: Current playback position in milliseconds.
         :param duration_ms: Current track duration in milliseconds.
@@ -336,7 +344,8 @@ class YnisonClient:
         await self._send(msg)
 
     async def update_session_params(self, mute_events_if_passive: bool = True) -> None:
-        """Configure session params on the Ynison server.
+        """
+        Configure session params on the Ynison server.
 
         `mute_events_if_passive=True` tells Ynison not to forward peer
         state updates while we're not the active device. Reduces inbound
@@ -355,7 +364,8 @@ class YnisonClient:
         await self._send(msg)
 
     async def sync_state_from_eov(self, actual_queue_id: str = "") -> None:
-        """Request queue sync from the EOV (Unified Playback Queue) backend.
+        """
+        Request queue sync from the EOV (Unified Playback Queue) backend.
 
         Asks the Ynison server to refresh the queue from the central EOV service.
         Only works when this device is the active player. If the EOV queue
@@ -378,7 +388,8 @@ class YnisonClient:
         *,
         strict: bool = False,
     ) -> None:
-        """Send player state update (queue changes, track skip).
+        """
+        Send player state update (queue changes, track skip).
 
         Unlike send_full_state, this does NOT reset active device status.
         Use this for track advances, queue modifications, repeat/shuffle changes.
@@ -424,7 +435,8 @@ class YnisonClient:
 
     @staticmethod
     def _message_meta() -> dict[str, Any]:
-        """Return common envelope fields for state-mutating messages.
+        """
+        Return common envelope fields for state-mutating messages.
 
         Ynison expects string-typed timestamps; integers cause 500 responses.
         """
@@ -435,7 +447,8 @@ class YnisonClient:
         }
 
     def _classify_state_as_echo(self, incoming_ps: dict[str, Any]) -> bool:
-        """Return True iff `incoming_ps` is our own broadcast round-tripping.
+        """
+        Return True iff `incoming_ps` is our own broadcast round-tripping.
 
         Uses author check on BOTH queue.version.device_id and
         status.version.device_id — only an update where every block was
@@ -526,7 +539,8 @@ class YnisonClient:
         }
 
     async def _get_redirect_ticket(self) -> tuple[str, str, int]:
-        """Connect to redirector and obtain redirect ticket.
+        """
+        Connect to redirector and obtain redirect ticket.
 
         :return: (host, redirect_ticket, session_id)
         :raises LoginFailed: If authentication fails.
@@ -758,7 +772,8 @@ class YnisonClient:
             )
 
     async def _reconnect(self) -> None:
-        """Reconnect with exponential backoff, retrying indefinitely.
+        """
+        Reconnect with exponential backoff, retrying indefinitely.
 
         On authentication failure (LoginFailed), attempts to refresh the token
         via the on_auth_failure callback before the next retry. The loop only
@@ -813,7 +828,8 @@ class YnisonClient:
                 self._logger.warning("Ynison reconnect attempt %d failed", attempt, exc_info=True)
 
     async def _send(self, msg: dict[str, Any], *, strict: bool = False) -> None:
-        """Send a JSON message to the state service (thread-safe).
+        """
+        Send a JSON message to the state service (thread-safe).
 
         :param msg: JSON-serialisable Ynison envelope.
         :param strict: When ``True``, transport failures (disconnected socket
@@ -837,7 +853,8 @@ class YnisonClient:
                     raise YnisonSendError("Ynison send failed") from exc
 
     def _schedule_reconnect(self) -> None:
-        """Schedule a background reconnect attempt if none is already in flight.
+        """
+        Schedule a background reconnect attempt if none is already in flight.
 
         Idempotent: a single reconnect task is in flight at any time. Becomes
         a no-op once :meth:`disconnect` has set ``_stop_event``.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,14 +6,13 @@ from unittest import mock
 
 import pytest
 from music_assistant_models.errors import LoginFailed
+from provider.auth import perform_qr_auth, refresh_music_token
 from ya_passport_auth import SecretStr
 from ya_passport_auth.exceptions import (
     InvalidCredentialsError,
     QRTimeoutError,
     YaPassportError,
 )
-
-from provider.auth import perform_qr_auth, refresh_music_token
 
 # ---------------------------------------------------------------
 # refresh_music_token
@@ -76,7 +75,8 @@ def _patched_passport(client: mock.AsyncMock) -> mock._patch[mock.MagicMock]:
 
 
 def _patched_auth_helper() -> tuple[mock._patch[mock.MagicMock], mock.MagicMock]:
-    """Patch music_assistant.helpers.auth.AuthenticationHelper at its source.
+    """
+    Patch music_assistant.helpers.auth.AuthenticationHelper at its source.
 
     perform_qr_auth lazy-imports this symbol inside the function body, so the
     patch target is the original module path — not ``provider.auth.``.

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock
 
 import pytest
 from music_assistant_models.errors import LoginFailed
-
 from provider import get_config_entries
 from provider.constants import (
     CONF_ACCOUNT_LOGIN,
@@ -108,7 +107,8 @@ async def test_selected_own_shows_token() -> None:
 
 
 async def test_upgrade_with_existing_token_preserves_own_mode() -> None:
-    """Upgrade from own-mode (CONF_TOKEN set, CONF_YM_INSTANCE absent) stays OWN.
+    """
+    Upgrade from own-mode (CONF_TOKEN set, CONF_YM_INSTANCE absent) stays OWN.
 
     Even if exactly one yandex_music instance exists, we must not silently
     switch the user's auth source on a no-op Save after upgrade.
@@ -285,7 +285,8 @@ async def test_own_mode_with_only_x_token_marks_token_optional() -> None:
 
 
 async def test_stale_ym_selection_normalizes_to_own() -> None:
-    """A saved selection pointing at a removed YM instance is normalized to OWN.
+    """
+    A saved selection pointing at a removed YM instance is normalized to OWN.
 
     Guards against the dropdown rendering with a default_value that is not in
     its options, AND ensures the in-memory `values` dict is rewritten so a

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -10,7 +10,8 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 def test_claude_local_md_documents_lossless_profile_correctly() -> None:
-    """`CLAUDE.local.md` auto-detection sentence must match the code constants.
+    """
+    `CLAUDE.local.md` auto-detection sentence must match the code constants.
 
     Derives the expected substring from `PCM_LOSSLESS_PARAMS` so a future
     constant change either flows through to the doc or fails this test

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -22,10 +22,6 @@ from music_assistant_models.errors import (
     UnsupportedFeaturedException,
 )
 from music_assistant_models.media_items import AudioFormat, AudioSource
-from ya_passport_auth import SecretStr
-from ya_passport_auth.ma import BorrowedCredentialSource, list_yandex_music_instances
-
-from music_assistant.helpers.throttle_retry import BYPASS_THROTTLER
 from provider.constants import (
     CONF_ALLOW_PLAYER_SWITCH,
     CONF_DEVICE_ID,
@@ -51,10 +47,15 @@ from provider.streaming import (
     make_pcm_format,
 )
 from provider.ynison_client import YnisonSendError, YnisonState
+from ya_passport_auth import SecretStr
+from ya_passport_auth.ma import BorrowedCredentialSource, list_yandex_music_instances
+
+from music_assistant.helpers.throttle_retry import BYPASS_THROTTLER
 
 
 def _arm_play_media_recorder(provider: YandexYnisonProvider) -> list[tuple[str, str]]:
-    """Replace `play_media` with a recorder and run `create_task` coros inline.
+    """
+    Replace `play_media` with a recorder and run `create_task` coros inline.
 
     Returns the list of (target_id, uri) tuples captured during the test.
     The inline create_task lets the scheduled `play_media` coroutine
@@ -291,7 +292,8 @@ class TestSourceSelection:
         assert provider._active_player_id is None
 
     async def test_on_source_selected_disabled_redirect_not_repeated(self) -> None:
-        """Repeated rejected selections must not re-issue the redirect play_media.
+        """
+        Repeated rejected selections must not re-issue the redirect play_media.
 
         When player switching is disabled and a non-target player keeps having
         the source selected (sendspin bridge / sync-group indirection re-triggers
@@ -935,14 +937,16 @@ class TestYnisonStateHandling:
             )
             provider._track_changed_event.set()
 
-        asyncio.create_task(simulate_echo_then_change())
+        echo_task = asyncio.create_task(simulate_echo_then_change())
         result = await provider._wait_for_track_change("old_track", timeout=5.0)
         assert result is True
+        await echo_task
 
     async def test_wait_for_track_change_returns_immediately_if_already_advanced(
         self,
     ) -> None:
-        """If Ynison already advanced before the call, return True without waiting.
+        """
+        If Ynison already advanced before the call, return True without waiting.
 
         Regression: _wait_for_track_change used to clear _track_changed_event
         before checking state, so a state update that arrived between
@@ -1097,7 +1101,8 @@ class TestPCMNormalization:
     async def test_stream_track_logs_output_rate_and_bit_depth(
         self, caplog: pytest.LogCaptureFixture
     ) -> None:
-        """The per-track stream log carries output sample rate AND bit depth.
+        """
+        The per-track stream log carries output sample rate AND bit depth.
 
         Spec 0006 AC6: with the passthrough fast path the declared PCM format
         IS the delivered audio, so an operator must read the output rate and
@@ -1154,7 +1159,8 @@ class TestPCMNormalization:
         assert mapping.audio_format.channels == 2
 
     async def test_superb_quality_uses_lossless_profile(self) -> None:
-        """When YM quality=superb and no hint, format is PCM s24le/44.1kHz.
+        """
+        When YM quality=superb and no hint, format is PCM s24le/44.1kHz.
 
         Spec 0006: the no-hint lossless floor is CD-rate (44.1 kHz), not
         48 kHz — a missing format hint must not upsample the common case.
@@ -1284,7 +1290,8 @@ class TestPCMNormalization:
     async def test_stream_track_provider_unloaded_mid_stream_aborts_cleanly(
         self,
     ) -> None:
-        """Unloaded linked provider mid-stream aborts cleanly (no AttributeError).
+        """
+        Unloaded linked provider mid-stream aborts cleanly (no AttributeError).
 
         Regression: the path between `await _get_stream_details_with_retry`
         and the ffmpeg stream builder used to dereference
@@ -1333,7 +1340,8 @@ def _make_ym_provider_stub(
 
 
 class TestPlayerRateSnap:
-    """_update_normalized_format snaps the declared rate to player capability.
+    """
+    _update_normalized_format snaps the declared rate to player capability.
 
     Spec 0006 AC9-11: the auto rate is snapped down to the nearest sample rate
     the target player supports, so MA's AudioSource passthrough fast path is
@@ -1980,7 +1988,8 @@ class TestPausePlayback:
         provider.mass.players.cmd_stop.assert_awaited_once_with("player1")
 
     async def test_rewrites_active_player_id_after_successful_cmd_stop(self) -> None:
-        """On a successful cmd_stop, `_active_player_id` demotes to the queue id.
+        """
+        On a successful cmd_stop, `_active_player_id` demotes to the queue id.
 
         Queues live on the bare ALSA UUID; bridge wrappers (`spb_*`) do
         not own one. Resume's `play_media(_active_player_id, ...)`
@@ -2011,7 +2020,8 @@ class TestPausePlayback:
         assert provider._externally_paused is True
 
     async def test_cmd_stop_failure_keeps_bridge_id_intact(self) -> None:
-        """A cmd_stop failure must not demote `_active_player_id`.
+        """
+        A cmd_stop failure must not demote `_active_player_id`.
 
         If we demoted to the queue id but cmd_stop never reached MA,
         the next `_activate_playback` would try `play_media(bare_uuid)`
@@ -2286,7 +2296,8 @@ class TestGetStreamDetailsWithRetry:
     async def test_unloaded_provider_raises_login_failed_not_attribute_error(
         self,
     ) -> None:
-        """Linked yandex_music unloaded → LoginFailed, not AttributeError.
+        """
+        Linked yandex_music unloaded → LoginFailed, not AttributeError.
 
         Regression: _yandex_provider can be set to None by the background
         _check_yandex_provider_match task between awaits in this function.
@@ -2425,7 +2436,8 @@ class TestActivatePlayback:
         provider.mass.create_task.assert_called()  # type: ignore[unreachable]
 
     async def test_unpause_after_external_pause_fires_play_media(self) -> None:
-        """Resume after pause schedules play_media for the (queue-id) player.
+        """
+        Resume after pause schedules play_media for the (queue-id) player.
 
         Simulates the post-`_pause_playback` state: `_stream_stop_event`
         set, `_active_player_id` already demoted to the queue id (the
@@ -2840,7 +2852,8 @@ class TestPrefetchOrdering:
 
 
 class TestPrefetchFlowsThroughToStreamDetails:
-    """`get_stream_details` returns the *prefetched* AudioFormat.
+    """
+    `get_stream_details` returns the *prefetched* AudioFormat.
 
     Pins the contract that MA's upstream passthrough path (#3969,
     `_select_audio_source_pcm_format`) honors: MA reads
@@ -2898,7 +2911,8 @@ class TestPrefetchFlowsThroughToStreamDetails:
         assert sd.audio_format.channels == 2
 
     async def test_streamdetails_audio_format_is_fresh_copy_per_call(self) -> None:
-        """Each `get_stream_details` returns a fresh AudioFormat instance.
+        """
+        Each `get_stream_details` returns a fresh AudioFormat instance.
 
         `AudioFormat` is mutable (MA's outer ffmpeg sets `codec_type` in
         place). A shared instance across `get_stream_details` calls
@@ -2944,7 +2958,8 @@ class TestAudioStreamPausedReturn:
 
 
 class TestNaturalEndDifferentiation:
-    """`_signal_track_completion` fires only on clean iterator exhaustion.
+    """
+    `_signal_track_completion` fires only on clean iterator exhaustion.
 
     These tests exercise the post-inner-loop branch via
     ``_wait_for_track_change`` as the outer-loop gate. The previous
@@ -2981,7 +2996,8 @@ class TestNaturalEndDifferentiation:
 
     @staticmethod
     def _gate_outer_loop_after_signal(provider: YandexYnisonProvider) -> None:
-        """`_wait_for_track_change` returns False → outer loop exits.
+        """
+        `_wait_for_track_change` returns False → outer loop exits.
 
         ``natural_end`` calls `_wait_for_track_change`; we use its
         return as the gate so the test terminates AFTER natural_end
@@ -3029,7 +3045,8 @@ class TestNaturalEndDifferentiation:
         assert calls == [1]
 
     async def test_track_change_during_chunk_loop_suppresses_signal(self) -> None:
-        """`_track_changed_event` set mid-stream → natural_end False → no signal.
+        """
+        `_track_changed_event` set mid-stream → natural_end False → no signal.
 
         Uses a two-invocation stub: first call arms `_track_changed_event`
         (the natural_end check we want to verify), second call sets
@@ -3065,7 +3082,8 @@ class TestNaturalEndDifferentiation:
         assert invocation_count == 2  # natural_end must have evaluated on pass 1
 
     async def test_session_change_during_chunk_loop_suppresses_signal(self) -> None:
-        """Session-id rotation mid-stream → `broke_for_session_change` → no signal.
+        """
+        Session-id rotation mid-stream → `broke_for_session_change` → no signal.
 
         The session-mismatch breaks both the inner chunk loop's break
         guard AND the outer-loop's session check, so the generator
@@ -3452,7 +3470,8 @@ class TestStrictModeDeliverySignal:
         assert any("Queue-advance dropped" in r.message for r in caplog.records)
 
     async def test_sync_progress_uses_non_strict_send(self) -> None:
-        """`_sync_progress` heartbeat must call into the non-strict send path.
+        """
+        `_sync_progress` heartbeat must call into the non-strict send path.
 
         Regression guard: heartbeats stay fire-and-forget so a single bad
         send tick does not crash the streaming generator. We verify the

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from music_assistant_models.enums import ContentType
 from music_assistant_models.media_items import AudioFormat
-
 from provider.streaming import (
     PCM_LOSSLESS_PARAMS,
     PCM_LOSSY_PARAMS,
@@ -20,7 +19,8 @@ class TestMakePcmFormat:
     """Tests for the AudioFormat factory."""
 
     def test_lossless_format(self) -> None:
-        """Lossless params produce s24le/44.1kHz/24bit/stereo.
+        """
+        Lossless params produce s24le/44.1kHz/24bit/stereo.
 
         The no-hint floor is 44.1 kHz (spec 0006): the bulk of the Yandex
         lossless catalogue is CD-rate FLAC, so a missing format hint must

--- a/tests/test_ynison_client.py
+++ b/tests/test_ynison_client.py
@@ -12,8 +12,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 import pytest
 from music_assistant_models.errors import LoginFailed
-from ya_passport_auth import SecretStr
-
 from provider.constants import (
     DEFAULT_APP_NAME,
     DEVICE_TYPE_WEB,
@@ -27,6 +25,7 @@ from provider.ynison_client import (
     generate_device_id,
     make_version_block,
 )
+from ya_passport_auth import SecretStr
 
 
 @pytest.fixture
@@ -284,7 +283,8 @@ class TestYnisonClientParseState:
         assert client.state.last_update_is_echo is True
 
     def test_echo_flag_false_when_only_queue_is_ours(self, client: YnisonClient) -> None:
-        """Status authored by peer → NOT echo, even if queue.version is ours.
+        """
+        Status authored by peer → NOT echo, even if queue.version is ours.
 
         Regression for the OR-logic bug: a peer toggling pause produced
         status.version=peer + our stale queue.version=ours, which the old
@@ -318,7 +318,8 @@ class TestYnisonClientParseState:
         assert client.state.last_update_is_echo is False
 
     def test_echo_flag_false_when_only_status_is_ours(self, client: YnisonClient) -> None:
-        """Queue authored by peer → NOT echo, even if status.version is ours.
+        """
+        Queue authored by peer → NOT echo, even if status.version is ours.
 
         The mirror case: our heartbeat just stamped status.version=ours, but
         the peer changed the queue. Under AND-logic the peer change is not
@@ -371,7 +372,8 @@ class TestYnisonClientParseState:
         assert client.state.last_update_is_echo is False
 
     def test_echo_flag_false_when_version_missing(self, client: YnisonClient) -> None:
-        """No version block at all → not an echo (safe default).
+        """
+        No version block at all → not an echo (safe default).
 
         AND-logic treats missing version-block as "not ours" — matches the
         previous safe default. Without a version-block we can't claim
@@ -393,7 +395,8 @@ class TestYnisonClientParseState:
         assert client.state.last_update_is_echo is False
 
     def test_parse_state_coerces_int_timestamps_to_strings(self, client: YnisonClient) -> None:
-        """Inbound int timestamps are stringified so outbound echoes stay safe.
+        """
+        Inbound int timestamps are stringified so outbound echoes stay safe.
 
         Guards the reconnect path (send_full_state echoes self.state.player_state)
         and queue-mutating update_player_state calls that shallow-copy status.
@@ -946,7 +949,8 @@ class TestConnectState:
             await client._message_task
 
     async def test_reconnect_sends_fresh_state_no_stale_replay(self, client: YnisonClient) -> None:
-        """v2.0: reconnect sends a fresh initial state — no stale replay.
+        """
+        v2.0: reconnect sends a fresh initial state — no stale replay.
 
         Replaying the last known state (which after a heartbeat could carry
         `paused=True`) caused the server to broadcast it back and trigger


### PR DESCRIPTION
## Description

Moves every `ConfigEntry` label/description/action_label and all static `ConfigValueOption` titles into `provider/strings.json`; `ConfigValueOption` calls are now value-only. Annotates `_RADIO_ENTITY_TYPES` as `ClassVar` (RUF012) and awaits the echo-simulation task in `test_provider.py` (RUF006).

Also includes the ruff 0.15 **safe** autofixes (D213 docstring style etc.) that provider CI would otherwise auto-commit on the next push once the new dev-mirrored lint config lands.

**Context:** trudenboy/ma-provider-tools#119 switches provider CI to full lint parity with `music-assistant/server` **dev** (dev-synced ruff rules, ruff 0.15, and a new *Upstream repo checks* gate running upstream's `check_*` pre-commit scripts). This PR fixes everything that gate and rule set flag in this repo, so CI stays green after the rollout — these were previously silent failures that would only surface on the first upstream PR.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] CI/Infrastructure
- [x] Refactoring

## Testing

- [ ] Tests pass locally (`uv run pytest`) — not run locally (needs full MA env); PR CI runs the suite
- [x] Lint passes — ruff 0.15 with the upstream-dev config: 0 findings; simulated the new *Upstream repo checks* gate against a fresh `music-assistant/server@dev` clone on Python 3.14: all checks green; `py3.14 -m compileall` clean
- [ ] New/changed code is covered by tests — no behavior change intended (texts move to strings.json)

## Checklist

- [x] Documentation updated if behavior changed (CHANGELOG entry added)
- [x] No secrets or credentials committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)